### PR TITLE
Add Xcode asset symbol generation

### DIFF
--- a/Tophat.xcodeproj/project.pbxproj
+++ b/Tophat.xcodeproj/project.pbxproj
@@ -826,7 +826,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1420;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1530;
 				ORGANIZATIONNAME = Shopify;
 				TargetAttributes = {
 					7F35024E24A5060500EE76EA = {
@@ -1112,6 +1112,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1174,6 +1175,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -1229,6 +1231,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = Tophat/Tophat.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
@@ -1253,6 +1256,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = Tophat/Tophat.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;

--- a/Tophat.xcodeproj/xcshareddata/xcschemes/Tophat.xcscheme
+++ b/Tophat.xcodeproj/xcshareddata/xcschemes/Tophat.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tophat.xcodeproj/xcshareddata/xcschemes/TophatTests.xcscheme
+++ b/Tophat.xcodeproj/xcshareddata/xcschemes/TophatTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1530"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tophat/Views/About/AboutView.swift
+++ b/Tophat/Views/About/AboutView.swift
@@ -13,7 +13,7 @@ struct AboutView: View {
 
 	var body: some View {
 		HStack(alignment: .center, spacing: 36) {
-			Image("SettingsAppIcon")
+            Image(.settingsAppIcon)
 				.resizable()
 				.scaledToFit()
 				.frame(width: 128, height: 128)

--- a/Tophat/Views/About/AboutView.swift
+++ b/Tophat/Views/About/AboutView.swift
@@ -13,7 +13,7 @@ struct AboutView: View {
 
 	var body: some View {
 		HStack(alignment: .center, spacing: 36) {
-            Image(.settingsAppIcon)
+			Image(.settingsAppIcon)
 				.resizable()
 				.scaledToFit()
 				.frame(width: 128, height: 128)

--- a/Tophat/Views/DeviceIsLockedView.swift
+++ b/Tophat/Views/DeviceIsLockedView.swift
@@ -15,7 +15,7 @@ struct DeviceIsLockedView: View {
 
 	var body: some View {
 		VStack(alignment: .center, spacing: 16) {
-            Image(.settingsAppIcon)
+			Image(.settingsAppIcon)
 				.resizable()
 				.interpolation(.high)
 				.scaledToFit()

--- a/Tophat/Views/DeviceIsLockedView.swift
+++ b/Tophat/Views/DeviceIsLockedView.swift
@@ -15,7 +15,7 @@ struct DeviceIsLockedView: View {
 
 	var body: some View {
 		VStack(alignment: .center, spacing: 16) {
-			Image("SettingsAppIcon")
+            Image(.settingsAppIcon)
 				.resizable()
 				.interpolation(.high)
 				.scaledToFit()

--- a/Tophat/Views/DeviceItem.swift
+++ b/Tophat/Views/DeviceItem.swift
@@ -48,7 +48,7 @@ struct DeviceItem: View {
 		} icon: {
 			ToggleableRowIcon(selected: selected) {
 				if device.runtime.platform == .android {
-					Image("android.fill")
+                    Image(.androidFill)
 						.resizable()
 						.scaledToFit()
 						.frame(maxWidth: 14)

--- a/Tophat/Views/DeviceItem.swift
+++ b/Tophat/Views/DeviceItem.swift
@@ -48,7 +48,7 @@ struct DeviceItem: View {
 		} icon: {
 			ToggleableRowIcon(selected: selected) {
 				if device.runtime.platform == .android {
-                    Image(.androidFill)
+					Image(.androidFill)
 						.resizable()
 						.scaledToFit()
 						.frame(maxWidth: 14)

--- a/Tophat/Views/Onboarding/AndroidStudioOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/AndroidStudioOnboardingItem.swift
@@ -16,7 +16,7 @@ struct AndroidStudioOnboardingItem: View {
 			title: "Android Studio",
 			description: "Tophat uses Android Studio to manage devices and install apps."
 		) {
-			Image("AndroidStudio")
+            Image(.androidStudio)
 				.resizable()
 				.interpolation(.high)
 				.padding(2)

--- a/Tophat/Views/Onboarding/AndroidStudioOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/AndroidStudioOnboardingItem.swift
@@ -16,7 +16,7 @@ struct AndroidStudioOnboardingItem: View {
 			title: "Android Studio",
 			description: "Tophat uses Android Studio to manage devices and install apps."
 		) {
-            Image(.androidStudio)
+			Image(.androidStudio)
 				.resizable()
 				.interpolation(.high)
 				.padding(2)

--- a/Tophat/Views/Onboarding/CommandLineHelperOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/CommandLineHelperOnboardingItem.swift
@@ -16,7 +16,7 @@ struct CommandLineHelperOnboardingItem: View {
 			title: "Command Line Helper",
 			description: "The `tophatctl` command allows you to control Tophat from the command line."
 		) {
-            Image(.terminal)
+			Image(.terminal)
 				.resizable()
 		} content: {
 			if symbolicLinkManager.isInstalled {

--- a/Tophat/Views/Onboarding/CommandLineHelperOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/CommandLineHelperOnboardingItem.swift
@@ -16,7 +16,7 @@ struct CommandLineHelperOnboardingItem: View {
 			title: "Command Line Helper",
 			description: "The `tophatctl` command allows you to control Tophat from the command line."
 		) {
-			Image("Terminal")
+            Image(.terminal)
 				.resizable()
 		} content: {
 			if symbolicLinkManager.isInstalled {

--- a/Tophat/Views/Onboarding/GoogleCloudStorageOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/GoogleCloudStorageOnboardingItem.swift
@@ -16,7 +16,7 @@ struct GoogleCloudStorageOnboardingItem: View {
 			title: "Google Cloud SDK",
 			description: "Tophat uses the Google Cloud SDK to download apps."
 		) {
-            Image(.googleCloudSDK)
+			Image(.googleCloudSDK)
 				.resizable()
 				.interpolation(.high)
 				.padding(5)

--- a/Tophat/Views/Onboarding/GoogleCloudStorageOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/GoogleCloudStorageOnboardingItem.swift
@@ -16,7 +16,7 @@ struct GoogleCloudStorageOnboardingItem: View {
 			title: "Google Cloud SDK",
 			description: "Tophat uses the Google Cloud SDK to download apps."
 		) {
-			Image("GoogleCloudSDK")
+            Image(.googleCloudSDK)
 				.resizable()
 				.interpolation(.high)
 				.padding(5)

--- a/Tophat/Views/Onboarding/OnboardingView.swift
+++ b/Tophat/Views/Onboarding/OnboardingView.swift
@@ -14,7 +14,7 @@ struct OnboardingView: View {
 	var body: some View {
 		VStack(alignment: .center, spacing: 36) {
 			VStack(spacing: 8) {
-                Image(.settingsAppIcon)
+				Image(.settingsAppIcon)
 					.resizable()
 					.scaledToFit()
 					.frame(width: 128, height: 128)

--- a/Tophat/Views/Onboarding/OnboardingView.swift
+++ b/Tophat/Views/Onboarding/OnboardingView.swift
@@ -14,7 +14,7 @@ struct OnboardingView: View {
 	var body: some View {
 		VStack(alignment: .center, spacing: 36) {
 			VStack(spacing: 8) {
-				Image("SettingsAppIcon")
+                Image(.settingsAppIcon)
 					.resizable()
 					.scaledToFit()
 					.frame(width: 128, height: 128)

--- a/Tophat/Views/Onboarding/ScreenCopyOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/ScreenCopyOnboardingItem.swift
@@ -16,7 +16,7 @@ struct ScreenCopyOnboardingItem: View {
 			title: "scrcpy",
 			description: "Tophat uses scrcpy to mirror the displays of Android devices."
 		) {
-            Image(.scrcpy)
+			Image(.scrcpy)
 				.resizable()
 				.interpolation(.high)
 				.padding(3)

--- a/Tophat/Views/Onboarding/ScreenCopyOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/ScreenCopyOnboardingItem.swift
@@ -16,7 +16,7 @@ struct ScreenCopyOnboardingItem: View {
 			title: "scrcpy",
 			description: "Tophat uses scrcpy to mirror the displays of Android devices."
 		) {
-			Image("scrcpy")
+            Image(.scrcpy)
 				.resizable()
 				.interpolation(.high)
 				.padding(3)

--- a/Tophat/Views/Onboarding/XcodeOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/XcodeOnboardingItem.swift
@@ -17,7 +17,7 @@ struct XcodeOnboardingItem: View {
 			title: "Xcode",
 			description: "Tophat uses Xcode to manage devices and install apps."
 		) {
-			Image("Xcode")
+            Image(.xcode)
 				.resizable()
 				.interpolation(.high)
 		} infoPopoverContent: {

--- a/Tophat/Views/Onboarding/XcodeOnboardingItem.swift
+++ b/Tophat/Views/Onboarding/XcodeOnboardingItem.swift
@@ -17,7 +17,7 @@ struct XcodeOnboardingItem: View {
 			title: "Xcode",
 			description: "Tophat uses Xcode to manage devices and install apps."
 		) {
-            Image(.xcode)
+			Image(.xcode)
 				.resizable()
 				.interpolation(.high)
 		} infoPopoverContent: {

--- a/Tophat/Views/Quick Launch/QuickLaunchAppView.swift
+++ b/Tophat/Views/Quick Launch/QuickLaunchAppView.swift
@@ -17,7 +17,7 @@ struct QuickLaunchAppView: View {
 				image
 					.pinnedApplicationImageStyle()
 			} placeholder: {
-				Image("AppIconPlaceholder")
+                Image(.appIconPlaceholder)
 					.pinnedApplicationImageStyle()
 			}
 

--- a/Tophat/Views/Quick Launch/QuickLaunchAppView.swift
+++ b/Tophat/Views/Quick Launch/QuickLaunchAppView.swift
@@ -17,7 +17,7 @@ struct QuickLaunchAppView: View {
 				image
 					.pinnedApplicationImageStyle()
 			} placeholder: {
-                Image(.appIconPlaceholder)
+				Image(.appIconPlaceholder)
 					.pinnedApplicationImageStyle()
 			}
 

--- a/Tophat/Views/Quick Launch/QuickLaunchEmptyState.swift
+++ b/Tophat/Views/Quick Launch/QuickLaunchEmptyState.swift
@@ -9,7 +9,7 @@
 import SwiftUI
 
 struct QuickLaunchEmptyState: View {
-	@AppStorage("SettingsSelectedTabIndex") var selectedTab: SettingsTab = .general
+	@AppStorage("SettingsSelectedTabIndex") private var selectedTab: SettingsTab = .general
 
 	var body: some View {
 		VStack(alignment: .center, spacing: 4) {

--- a/Tophat/Views/Settings/PinnedApplicationRow.swift
+++ b/Tophat/Views/Settings/PinnedApplicationRow.swift
@@ -20,7 +20,7 @@ struct PinnedApplicationRow: View {
 				image
 					.pinnedApplicationImageStyle()
 			} placeholder: {
-                Image(.appIconPlaceholder)
+				Image(.appIconPlaceholder)
 					.pinnedApplicationImageStyle()
 			}
 			VStack(alignment: .leading, spacing: 3) {

--- a/Tophat/Views/Settings/PinnedApplicationRow.swift
+++ b/Tophat/Views/Settings/PinnedApplicationRow.swift
@@ -20,7 +20,7 @@ struct PinnedApplicationRow: View {
 				image
 					.pinnedApplicationImageStyle()
 			} placeholder: {
-				Image("AppIconPlaceholder")
+                Image(.appIconPlaceholder)
 					.pinnedApplicationImageStyle()
 			}
 			VStack(alignment: .leading, spacing: 3) {

--- a/Tophat/Views/SettingsView.swift
+++ b/Tophat/Views/SettingsView.swift
@@ -9,14 +9,14 @@
 import SwiftUI
 
 enum SettingsTab: Int {
-	case general = 0
-	case apps = 1
-	case devices = 2
-	case locations = 3
+	case general
+	case apps
+	case devices
+	case locations
 }
 
 struct SettingsView: View {
-	@AppStorage("SettingsSelectedTabIndex") var selectedTab: SettingsTab = .general
+	@AppStorage("SettingsSelectedTabIndex") private var selectedTab: SettingsTab = .general
 
 	var body: some View {
 		TabView(selection: $selectedTab) {


### PR DESCRIPTION
### What does this change accomplish?
Use automatically generated safe assets. This feature is available starting from Xcode 15 and turned on by default.

### How have you achieved it?
Replace the plain strings with generated type-safe assets 

### How can the change be tested?
1. Open any screen with any updated image and it should still be the same after this PR update