### PR TITLE
Bump ZIPFoundation to `0.9.19`

### DIFF
--- a/Tophat.xcodeproj/project.pbxproj
+++ b/Tophat.xcodeproj/project.pbxproj
@@ -1448,7 +1448,7 @@
 			repositoryURL = "https://github.com/weichsel/ZIPFoundation";
 			requirement = {
 				kind = exactVersion;
-				version = 0.9.16;
+				version = 0.9.19;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Tophat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Tophat.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/weichsel/ZIPFoundation",
       "state" : {
-        "revision" : "43ec568034b3731101dbf7670765d671c30f54f3",
-        "version" : "0.9.16"
+        "revision" : "02b6abe5f6eef7e3cbd5f247c5cc24e246efcfe0",
+        "version" : "0.9.19"
       }
     }
   ],


### PR DESCRIPTION
### What does this change accomplish?

This change bumps the ZIPFoundation version to 0.9.19 as a 0.9.18 fixes a known security vulnerability.

### How have you achieved it?

By updating the version in the Xcode project.

### How can the change be tested?

1. Build and run Tophat.
2. Ensure the app is able to download and install applications.
