### PR TITLE
Terminate app on iOS simulator before install to address iOS 18 change

### DIFF
--- a/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+SimCtl.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+SimCtl.swift
@@ -27,6 +27,7 @@ enum SimCtlCommand {
 	case boot(device: String)
 	case install(device: String, bundleUrl: URL)
 	case launch(device: String, bundleIdentifier: String, arguments: [String])
+	case terminate(device: String, bundleIdentifier: String)
 }
 
 extension SimCtlCommand: ShellCommand {
@@ -47,6 +48,9 @@ extension SimCtlCommand: ShellCommand {
 
 			case .launch(let device, let bundleIdentifier, let arguments):
 				return ["simctl", "launch", device, bundleIdentifier] + arguments
+
+			case .terminate(let device, let bundleIdentifier):
+				return ["simctl", "terminate", device, bundleIdentifier]
 		}
 	}
 }

--- a/TophatModules/Sources/AppleDeviceKit/Simulator+Device.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Simulator+Device.swift
@@ -56,6 +56,9 @@ extension Simulator: Device {
 
 	func install(application: Application) throws {
 		do {
+			// Failure to terminate is permitted as the application may not be running.
+			try? SimCtl.terminate(udid: id, bundleIdentifier: application.bundleIdentifier)
+
 			try SimCtl.install(udid: id, bundleUrl: application.url)
 		} catch {
 			throw DeviceError.failedToInstallApp(bundleUrl: application.url, deviceType: .virtual)

--- a/TophatModules/Sources/AppleDeviceKit/Utilities/SimCtl.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Utilities/SimCtl.swift
@@ -37,6 +37,10 @@ final class SimCtl {
 	static func launch(udid: String, bundleIdentifier: String, arguments: [String]) throws {
 		try run(command: .simCtl(.launch(device: udid, bundleIdentifier: bundleIdentifier, arguments: arguments)), log: log)
 	}
+
+	static func terminate(udid: String, bundleIdentifier: String) throws {
+		try run(command: .simCtl(.terminate(device: udid, bundleIdentifier: bundleIdentifier)), log: log)
+	}
 }
 
 private extension Simulator {


### PR DESCRIPTION
### What does this change accomplish?

This change addresses a change in behaviour introduced with the iOS 18 simulators whereby installing an application does not implicitly terminate any existing instances of that application, thereby causing the launch of a newly installed copy of the application to fail.

### How have you achieved it?

By explicitly telling `simctl` to terminate the running instance before installing.

### How can the change be tested?

1. Launch Tophat
2. Install a build to an iOS 18 simulator with no apps running.
3. Install a build of the same application again and ensure that the old application is killed, and the new application is then installed and launched.
