### PR TITLE
Bump version to `1.11.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ Tophat also adds file associations to `*.ipa`, `*.apk`, and `*.zip` files so you
 
 ## Getting Started
 
-The easiest way to run Tophat safely is to build it from source by opening `Tophat.xcodeproj` using Xcode. Alternatively, you can download a pre-built (but unsigned) binary of the latest release from the [releases](https://github.com/Shopify/tophat/releases) page.
+A signed universal binary of Tophat can be downloaded from the latest GitHub release. Click the button below to jump to it, download the `.zip` file, and move Tophat to your Applications folder:
+
+[![Latest GitHub Release](https://img.shields.io/github/v/release/Shopify/tophat?color=black&label=download%20latest&logo=github&sort=semver&style=for-the-badge)](https://github.com/Shopify/tophat/releases/latest)
+
+A full list of releases is available [here](https://github.com/Shopify/tophat/releases).
+
+Tophat will automatically check for updates and let you know if a new one is available. Youʼll be prompted to enable automatic update checks the second time you launch Tophat. Automatic updates can also be configured from Tophatʼs Settings window.
 
 Tophat requires a few developer tools to be set up. On first launch, Tophat will guide you through making sure everything you need is ready to go.
 

--- a/Tophat.xcodeproj/project.pbxproj
+++ b/Tophat.xcodeproj/project.pbxproj
@@ -1168,7 +1168,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = A7XGC83MZE;
@@ -1180,7 +1180,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Tophat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -1196,7 +1196,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 29;
+				CURRENT_PROJECT_VERSION = 1;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "";
 				DEVELOPMENT_TEAM = "";
@@ -1209,7 +1209,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MARKETING_VERSION = 1.10.0;
+				MARKETING_VERSION = 1.11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Tophat;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";


### PR DESCRIPTION
### What does this change accomplish?

This change bumps the version to 1.11.0, and updates the README to contain a link to the latest release.  It also resets the build number to `1` as this is overridden by an internal tool used for releases.

### How have you achieved it?

N/A

### How can the change be tested?

N/A