### PR TITLE
fix: read package name from aapt

### DIFF
--- a/Tophat/Models/AndroidApplication.swift
+++ b/Tophat/Models/AndroidApplication.swift
@@ -43,7 +43,7 @@ struct AndroidApplication: Application {
 
 	var bundleIdentifier: String {
 		get throws {
-			guard let packageName = try? ApkAnalyzer.readPackageName(apkUrl: url) else {
+			guard let packageName = try? Aapt.readPackageName(apkUrl: url) else {
 				throw ApplicationError.failedToReadBundleIdentifier
 			}
 

--- a/TophatModules/Sources/AndroidDeviceKit/Extensions/ShellCommand+Aapt.swift
+++ b/TophatModules/Sources/AndroidDeviceKit/Extensions/ShellCommand+Aapt.swift
@@ -16,7 +16,7 @@ extension ShellCommand where Self == AaptCommand {
 }
 
 enum AaptCommand {
-	case name(apkUrl: URL)
+	case dumpBadging(apkUrl: URL)
 }
 
 extension AaptCommand: ShellCommand {
@@ -38,7 +38,7 @@ extension AaptCommand: ShellCommand {
 
 	var arguments: [String] {
 		switch self {
-			case .name(let apkUrl):
+			case .dumpBadging(let apkUrl):
 				return ["dump", "badging", apkUrl.path(percentEncoded: false).wrappedInQuotationMarks()]
 		}
 	}

--- a/TophatModules/Sources/AndroidDeviceKit/Extensions/ShellCommand+ApkAnalyzer.swift
+++ b/TophatModules/Sources/AndroidDeviceKit/Extensions/ShellCommand+ApkAnalyzer.swift
@@ -16,7 +16,6 @@ extension ShellCommand where Self == ApkAnalyzerCommand {
 }
 
 enum ApkAnalyzerCommand {
-	case manifest(apkUrl: URL)
 	case icon(apkUrl: URL)
 }
 
@@ -39,8 +38,6 @@ extension ApkAnalyzerCommand: ShellCommand {
 
 	var arguments: [String] {
 		switch self {
-			case .manifest(let apkUrl):
-				return ["manifest", "application-id", apkUrl.path(percentEncoded: false).wrappedInQuotationMarks()]
 			case .icon(let apkUrl):
 				return ["resources", "value", "--config", "xxhdpi", "--name", "ic_launcher", "--type", "mipmap", apkUrl.path(percentEncoded: false).wrappedInQuotationMarks()]
 		}

--- a/TophatModules/Sources/AndroidDeviceKit/Utilities/Aapt.swift
+++ b/TophatModules/Sources/AndroidDeviceKit/Utilities/Aapt.swift
@@ -21,9 +21,28 @@ public struct Aapt {
 		"'"
 	}
 
+	private static let packageNameRegex = Regex {
+		"package: name='"
+		Capture {
+			OneOrMore(CharacterClass(.anyNonNewline))
+		}
+		"'"
+	}
+
+	public static func readPackageName(apkUrl: URL) throws -> String {
+		do {
+			let output = try run(command: .aapt(.dumpBadging(apkUrl: apkUrl)), log: log)
+			if let match = output.firstMatch(of: packageNameRegex) {
+				return String(match.1)
+			}
+		} catch {
+		}
+		throw AaptError()
+	}
+
 	public static func readAppName(apkUrl: URL) throws -> String? {
 		do {
-			let output = try run(command: .aapt(.name(apkUrl: apkUrl)), log: log)
+			let output = try run(command: .aapt(.dumpBadging(apkUrl: apkUrl)), log: log)
 			if let match = output.firstMatch(of: appNameRegex) {
 				return String(match.1)
 			}

--- a/TophatModules/Sources/AndroidDeviceKit/Utilities/ApkAnalyzer.swift
+++ b/TophatModules/Sources/AndroidDeviceKit/Utilities/ApkAnalyzer.swift
@@ -12,14 +12,6 @@ import ShellKit
 class ApkAnalyzerError: Error {}
 
 public struct ApkAnalyzer {
-	public static func readPackageName(apkUrl: URL) throws -> String {
-		do {
-			return try run(command: .apkAnalyzer(.manifest(apkUrl: apkUrl)), log: log)
-		} catch {
-			throw ApkAnalyzerError()
-		}
-	}
-
 	public static func getIconPath(apkUrl: URL) throws -> String {
 		do {
 			return try run(command: .apkAnalyzer(.icon(apkUrl: apkUrl)), log: log)


### PR DESCRIPTION
### What does this change accomplish?

Fixes [Cannot launch Expo Android apps](https://github.com/Shopify/tophat/issues/26) by using Aapt to get the package name instead of APK analyzer. This is the same solution used by Expo Orbit.

Resolves #26 

### How have you achieved it?

Apk Analyzer was not interpreting the Android Manifest correctly for Expo apps. I've switched to Aapt, which was already used to get the App Name, as it provides a better parsing in this scenario.

### How can the change be tested?

1. Open Android app built with Expo in Tophat
2. See the app is downloaded correctly on the Device
3. See the app launches, instead of throwing an error
