### PR TITLE
fix: detect build tools dynamically

### DIFF
--- a/TophatModules/Sources/AndroidDeviceKit/AndroidPathResolver.swift
+++ b/TophatModules/Sources/AndroidDeviceKit/AndroidPathResolver.swift
@@ -87,21 +87,21 @@ public struct AndroidPathResolver {
 
 	static func buildTool(named name: String) -> URL? {
 		let buildToolsDir = sdkRoot.appending(path: "build-tools")
-		
+
 		guard let contents = try? FileManager.default.contentsOfDirectory(
 			at: buildToolsDir,
 			includingPropertiesForKeys: [.isDirectoryKey],
 			options: .skipsHiddenFiles
 		) else {
-			return nil;
+			return nil
 		}
-		
+
 		let toolPaths = contents
 			.filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false }
 			.map { $0.appending(path: name) }
 			.filter { $0.isReachable() }
 			.sorted { $0.path > $1.path }
-			
+
 		return toolPaths.first
 	}
 }


### PR DESCRIPTION
### What does this change accomplish?

Resolves https://github.com/Shopify/tophat/issues/30
<!-- Describe what you're implementing. Are you fixing a bug? Adding a new feature? Describe it with detail! -->

This PR adds automatic build tools detection to Tophat, similar to what Expo Orbit offers.

This allows us to rely on the available build-tools provided by the Android Studio installation as opposed to forcing the user to manually download the hardcoded versions we currently have.

<!-- If this pull request closes an issue, link it here using the Resolves keyword. -->

### How have you achieved it?

I noticed Tophat was not recognizing AAPT by default, and looking at the logs and code I noticed it was looking for v33.0.0 - the default installed version is v35.0.0, which causes the error while attempting to find build-tools.

I've looked at other approaches and found Expo Orbits does a folder search to find the AAPT version. This PR implements something similar to make the installation process more flexible.

<!-- How did you approach the problem and why? -->

### How can the change be tested?

- Download Android Studio
- See build-tools installed as 35.0.0 by default
- Open Tophat
- Attempt to Launch an Android App
- See it succeeding, as build-tools 35.0.0 gets found

<img width="579" alt="Screenshot 2024-11-08 at 14 18 41" src="https://github.com/user-attachments/assets/16514f28-9d63-4d38-af66-f94bcc559438">

<!-- Provide step-by-step instructions so that reviewers can test this change. -->
