### PR TITLE
Forward localized descriptions of extension errors to host

### DIFF
--- a/TophatKit/Sources/TophatKit/ArtifactProvider.swift
+++ b/TophatKit/Sources/TophatKit/ArtifactProvider.swift
@@ -35,6 +35,9 @@ public protocol ArtifactProvider {
 	///
 	/// Throw any errors if they ocurred. Use any parameters wrapped with ``Parameter`` to
 	/// collect inputs from Tophat to implement the retrieval mechanism.
+	///
+	/// To display an error message in the user interface, conform thrown errors to the
+	/// `LocalizedError` protocol.
 	/// - Returns: A ``ArtifactProviderResult`` containing the output.
 	func retrieve() async throws -> Result
 

--- a/TophatKit/Sources/TophatKit/Internal/XPC/ExtensionXPCGenericLocalizedError.swift
+++ b/TophatKit/Sources/TophatKit/Internal/XPC/ExtensionXPCGenericLocalizedError.swift
@@ -1,0 +1,28 @@
+//
+//  ExtensionXPCGenericLocalizedError.swift
+//  TophatKit
+//
+//  Created by Lukas Romsicki on 2024-11-27.
+//
+
+import Foundation
+
+struct ExtensionXPCGenericLocalizedError: LocalizedError {
+	let errorDescription: String?
+	let failureReason: String?
+	let recoverySuggestion: String?
+	let helpAnchor: String?
+
+	init?(nsError: NSError) {
+		let userInfo = nsError.userInfo
+
+		self.errorDescription = userInfo["errorDescription"] as? String
+		self.failureReason = userInfo["failureReason"] as? String
+		self.recoverySuggestion = userInfo["recoverySuggestion"] as? String
+		self.helpAnchor = userInfo["helpAnchor"] as? String
+
+		guard errorDescription != nil || failureReason != nil || recoverySuggestion != nil || helpAnchor != nil else {
+			return nil
+		}
+	}
+}

--- a/TophatKit/Sources/TophatKit/Internal/XPC/ExtensionXPCReceivedMessage.swift
+++ b/TophatKit/Sources/TophatKit/Internal/XPC/ExtensionXPCReceivedMessage.swift
@@ -39,7 +39,8 @@ struct ExtensionXPCReceivedMessageContainer {
 					replyHandler(nil, error)
 				}
 			case .failure(let error):
-				replyHandler(nil, error)
+				// The error will be an NSError over XPC anyway.
+				replyHandler(nil, NSError(embeddingLocalizedDescriptionsFrom: error))
 		}
 	}
 }

--- a/TophatKit/Sources/TophatKit/Internal/XPC/ExtensionXPCSession.swift
+++ b/TophatKit/Sources/TophatKit/Internal/XPC/ExtensionXPCSession.swift
@@ -82,7 +82,10 @@ extension ExtensionXPCSession {
 			}
 
 			service.send(identifier: message.identifier, data: dataToSend) { dataFromReply, error in
-				if let error {
+				if let nsError = error as? NSError, let localizedError = ExtensionXPCGenericLocalizedError(nsError: nsError) {
+					continuation.resume(throwing: localizedError)
+					return
+				} else if let error {
 					continuation.resume(throwing: error)
 					return
 				}

--- a/TophatKit/Sources/TophatKit/Internal/XPC/NSError+Extensions.swift
+++ b/TophatKit/Sources/TophatKit/Internal/XPC/NSError+Extensions.swift
@@ -1,0 +1,24 @@
+//
+//  NSError+Extensions.swift
+//  TophatKit
+//
+//  Created by Lukas Romsicki on 2024-11-27.
+//
+
+import Foundation
+
+extension NSError {
+	convenience init(embeddingLocalizedDescriptionsFrom error: Error) {
+		let nsError = error as NSError
+		var newUserInfo = nsError.userInfo
+
+		if let localizedError = error as? LocalizedError {
+			newUserInfo["errorDescription"] = localizedError.errorDescription
+			newUserInfo["failureReason"] = localizedError.failureReason
+			newUserInfo["recoverySuggestion"] = localizedError.recoverySuggestion
+			newUserInfo["helpAnchor"] = localizedError.helpAnchor
+		}
+
+		self.init(domain: nsError.domain, code: nsError.code, userInfo: newUserInfo)
+	}
+}


### PR DESCRIPTION
### What does this change accomplish?

Currently, any errors thrown from extensions are considered "generic failures" with no meaningful information for the user.  This change updates the code to forward localized error descriptions over XPC.

### How have you achieved it?

By injecting localized error descriptions into the `NSError` `userInfo` dictionary (since all errors are converted to `NSError` for sending over XPC) and reconstructing a generic localized error on the receiving end with the information.

### How can the change be tested?

1. Throw an error conforming to `LocalizedError` from an `ArtifactProvider` in an extension.
2. Observe that you see an alert containing the description you specified.
