### PR TITLE
Update Xcode project to use folders instead of groups

### DIFF
--- a/Tophat.xcodeproj/project.pbxproj
+++ b/Tophat.xcodeproj/project.pbxproj
@@ -3,172 +3,33 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 73;
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6038BC5B50B9DB89F651A6EA /* Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6038B795B47D50A397AF03DB /* Notifications.swift */; };
-		7F35025724A5060600EE76EA /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7F35025624A5060600EE76EA /* Assets.xcassets */; };
-		7F35026924A5060700EE76EA /* TophatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F35026824A5060700EE76EA /* TophatTests.swift */; };
 		7F4532AD251A6C4700F2CFC8 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 7FA71E0924C95CAC001C9574 /* Logging */; };
 		7F4532AF251A6C4700F2CFC8 /* LoggingOSLog in Frameworks */ = {isa = PBXBuildFile; productRef = 7F8EC94425086F3B00D4D42B /* LoggingOSLog */; };
 		8001A4812CF9275400325E7B /* SimpleKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 8001A4802CF9275400325E7B /* SimpleKeychain */; };
 		8005282F2CB718C200226174 /* TophatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8005282E2CB718C200226174 /* TophatKit */; };
 		800528312CB718C700226174 /* TophatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 800528302CB718C700226174 /* TophatKit */; };
-		8006E7E12943C9190089805E /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006E7E02943C9190089805E /* Theme.swift */; };
-		8006E7E32943C95D0089805E /* MenuItemButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006E7E22943C95D0089805E /* MenuItemButtonStyle.swift */; };
-		8006E7E52943C9970089805E /* SectionHeadingTextStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006E7E42943C9970089805E /* SectionHeadingTextStyle.swift */; };
-		8006E7E72943C9AA0089805E /* ToggleableRowIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006E7E62943C9AA0089805E /* ToggleableRowIcon.swift */; };
-		8006E7E92943C9B80089805E /* ToggleableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006E7E82943C9B80089805E /* ToggleableRow.swift */; };
-		8006E7ED2943CA250089805E /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8006E7EC2943CA250089805E /* Panel.swift */; };
 		8006E7F02943D3090089805E /* VisualEffects in Frameworks */ = {isa = PBXBuildFile; productRef = 8006E7EF2943D3090089805E /* VisualEffects */; };
-		8020A6DE297F301700FEA490 /* URLReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8020A6DD297F301700FEA490 /* URLReader.swift */; };
-		8025A5B429845EB5007B1BA0 /* Apps.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8025A5B329845EB5007B1BA0 /* Apps.swift */; };
-		802671452947C297001A804D /* MenuHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802671442947C297001A804D /* MenuHeader.swift */; };
-		802671472947C33C001A804D /* Bundle+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802671462947C33C001A804D /* Bundle+Extensions.swift */; };
-		802671492947C72C001A804D /* QuickLaunchEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802671482947C72C001A804D /* QuickLaunchEntryView.swift */; };
-		8026714B2947C770001A804D /* QuickLaunchPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8026714A2947C770001A804D /* QuickLaunchPanel.swift */; };
-		8029A081298AF1E90002C579 /* ApplicationIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8029A080298AF1E90002C579 /* ApplicationIcon.swift */; };
-		8029B6A52AC239E000BD1D30 /* DeviceIsLockedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8029B6A42AC239E000BD1D30 /* DeviceIsLockedView.swift */; };
-		8029B6A72AC239FE00BD1D30 /* DeviceIsLockedViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8029B6A62AC239FE00BD1D30 /* DeviceIsLockedViewModifier.swift */; };
-		80301620292874B70016F25E /* ArtifactUnpacker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8030161F292874B70016F25E /* ArtifactUnpacker.swift */; };
-		80301626292C17560016F25E /* AppleApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80301625292C17560016F25E /* AppleApplication.swift */; };
-		80301628292C17700016F25E /* AndroidApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80301627292C17700016F25E /* AndroidApplication.swift */; };
-		8030162C292C1B490016F25E /* ApplicationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8030162B292C1B490016F25E /* ApplicationError.swift */; };
-		80343E472CA39A1D00642D54 /* ExtensionsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80343E462CA39A1A00642D54 /* ExtensionsTab.swift */; };
 		80346F042BEBD527002F54BC /* AsyncAlgorithms in Frameworks */ = {isa = PBXBuildFile; productRef = 80346F032BEBD527002F54BC /* AsyncAlgorithms */; };
 		803B874B290055C70062F070 /* AndroidDeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 803B874A290055C70062F070 /* AndroidDeviceKit */; };
-		80462F8F2CEFA780002F6E8F /* InfoButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80462F8E2CEFA77E002F6E8F /* InfoButton.swift */; };
-		80462F912CEFA7F2002F6E8F /* ParameterTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80462F902CEFA7EF002F6E8F /* ParameterTextField.swift */; };
-		80462F942CEFEF1A002F6E8F /* TophatExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80462F932CEFEF17002F6E8F /* TophatExtension.swift */; };
-		80462F972CEFEF73002F6E8F /* ExtensionHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80462F962CEFEF70002F6E8F /* ExtensionHost.swift */; };
-		80462F992CEFF04F002F6E8F /* AppExtensionIdentity+WithXPCSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80462F982CEFF04A002F6E8F /* AppExtensionIdentity+WithXPCSession.swift */; };
-		8046321F2CF106D5002F6E8F /* QuickLaunchEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8046321E2CF106C9002F6E8F /* QuickLaunchEntry.swift */; };
-		804ECB7C2975C15300DE78F4 /* DevicePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804ECB7B2975C15300DE78F4 /* DevicePicker.swift */; };
-		804ECB7E2975C18300DE78F4 /* DeviceMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804ECB7D2975C18300DE78F4 /* DeviceMenu.swift */; };
-		804ECB802975C68400DE78F4 /* VisibleWhenButtonHoveredViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804ECB7F2975C68400DE78F4 /* VisibleWhenButtonHoveredViewModifier.swift */; };
-		804F37F92C7CE46F0005A869 /* HostTrustResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804F37F82C7CE46F0005A869 /* HostTrustResult.swift */; };
-		804F37FD2C7CEFB00005A869 /* TrustedHostAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804F37FC2C7CEFB00005A869 /* TrustedHostAlert.swift */; };
-		804FF6592914239800147652 /* Collection+Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 804FF6582914239800147652 /* Collection+Filter.swift */; };
-		80518F4F2984600900FB8803 /* Apps+Add.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80518F4D29845FB100FB8803 /* Apps+Add.swift */; };
-		80518F512984681200FB8803 /* Apps+Remove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80518F502984681200FB8803 /* Apps+Remove.swift */; };
-		80518F5329846E4300FB8803 /* NSRunningApplication+IsTophatRunning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80518F5229846E4300FB8803 /* NSRunningApplication+IsTophatRunning.swift */; };
-		80518F572984804C00FB8803 /* TophatCtlSymbolicLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80518F562984804C00FB8803 /* TophatCtlSymbolicLinkManager.swift */; };
-		80518F632984A64F00FB8803 /* OnboardingWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80518F622984A64F00FB8803 /* OnboardingWindow.swift */; };
-		80518F682984A6BF00FB8803 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80518F672984A6BF00FB8803 /* OnboardingView.swift */; };
 		805543CC2CB715EB004E1D18 /* TophatUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 805543CB2CB715EB004E1D18 /* TophatUtilities */; };
 		805543CE2CB715F1004E1D18 /* TophatUtilities in Frameworks */ = {isa = PBXBuildFile; productRef = 805543CD2CB715F1004E1D18 /* TophatUtilities */; };
-		80564B5229834137002DC136 /* TaskStatusReporterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80564B5129834137002DC136 /* TaskStatusReporterDelegate.swift */; };
-		80564B542983414D002DC136 /* AlertOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80564B532983414D002DC136 /* AlertOptions.swift */; };
-		80564B5629834203002DC136 /* FileTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80564B5529834203002DC136 /* FileTypes.swift */; };
-		8058B48C2CA630620075D38D /* URLReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8058B48B2CA630620075D38D /* URLReaderTests.swift */; };
-		805AFDAA2CF67D4C00B3E227 /* ArtifactContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805AFDA92CF67D4900B3E227 /* ArtifactContainer.swift */; };
-		805AFDAC2CF6BB8D00B3E227 /* CachingApplicationDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805AFDAB2CF6BB8900B3E227 /* CachingApplicationDownloader.swift */; };
-		805AFDAE2CF6C22700B3E227 /* InstallSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805AFDAD2CF6C21F00B3E227 /* InstallSession.swift */; };
-		805FC43229E9BE0A00A78208 /* ArtifactDownloaderError+LocalizedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805FC43129E9BE0A00A78208 /* ArtifactDownloaderError+LocalizedError.swift */; };
-		80629BF12939818C0077960E /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BE92939818C0077960E /* SettingsView.swift */; };
-		80629BF22939818C0077960E /* QuickLaunchEntryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BEC2939818C0077960E /* QuickLaunchEntryRow.swift */; };
-		80629BF32939818C0077960E /* List+GradientButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BED2939818C0077960E /* List+GradientButtons.swift */; };
-		80629BF42939818C0077960E /* QuickLaunchEntrySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BEE2939818C0077960E /* QuickLaunchEntrySheet.swift */; };
-		80629BF52939818C0077960E /* AppsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BEF2939818C0077960E /* AppsTab.swift */; };
-		80629BF62939818C0077960E /* GradientButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BF02939818C0077960E /* GradientButton.swift */; };
-		80629BF82939819F0077960E /* String+IsValidURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BF72939819F0077960E /* String+IsValidURL.swift */; };
-		80629BFC293981B10077960E /* CodableAppStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629BFB293981B10077960E /* CodableAppStorage.swift */; };
-		80629C22293A8D270077960E /* ProvisioningProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80629C21293A8D270077960E /* ProvisioningProfile.swift */; };
-		80691D282CDA9AE9006572CD /* ArtifactDownloader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80691D272CDA9ADE006572CD /* ArtifactDownloader.swift */; };
-		8079E3562C850FE0000CB5B3 /* View+ShowDockIconWhenOpen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8079E3552C850FE0000CB5B3 /* View+ShowDockIconWhenOpen.swift */; };
 		807D7B0F29835762007942B4 /* TophatFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 807D7B0E29835762007942B4 /* TophatFoundation */; };
-		807D7B132983576C007942B4 /* TophatCtl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 807D7B102983576C007942B4 /* TophatCtl.swift */; };
 		807D7B1629835795007942B4 /* ArgumentParser in Frameworks */ = {isa = PBXBuildFile; productRef = 807D7B1529835795007942B4 /* ArgumentParser */; };
 		807D7B1A298357C6007942B4 /* tophatctl in Copy tophatctl */ = {isa = PBXBuildFile; fileRef = 807D7B0729835756007942B4 /* tophatctl */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		808C6E3A2CF8D81F0030359E /* TophatBitriseExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = 808C6E322CF8D81F0030359E /* TophatBitriseExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		808C6E462CF8D8600030359E /* TophatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 808C6E452CF8D8600030359E /* TophatKit */; };
 		8090E201294FA29E003106B9 /* FluidMenuBarExtra in Frameworks */ = {isa = PBXBuildFile; productRef = 8090E200294FA29E003106B9 /* FluidMenuBarExtra */; };
-		8090E2032950C1CC003106B9 /* CollapsibleSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2022950C1CC003106B9 /* CollapsibleSection.swift */; };
-		8090E2132950E01E003106B9 /* DeviceList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2122950E01E003106B9 /* DeviceList.swift */; };
-		8090E25A2967741F003106B9 /* TaskProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2562967741F003106B9 /* TaskProgress.swift */; };
-		8090E25B2967741F003106B9 /* TaskState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2572967741F003106B9 /* TaskState.swift */; };
-		8090E25C2967741F003106B9 /* TaskStatusReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2582967741F003106B9 /* TaskStatusReporter.swift */; };
-		8090E25D2967741F003106B9 /* TaskStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2592967741F003106B9 /* TaskStatus.swift */; };
-		8090E25F29677489003106B9 /* MainProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E25E29677489003106B9 /* MainProgressView.swift */; };
-		8090E2612967749F003106B9 /* TophatProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E2602967749F003106B9 /* TophatProgressViewStyle.swift */; };
-		8090E263296774C1003106B9 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E262296774C1003106B9 /* StatusView.swift */; };
-		8090E265296774D2003106B9 /* StatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8090E264296774D2003106B9 /* StatusPopover.swift */; };
 		8090E268296775BE003106B9 /* Collections in Frameworks */ = {isa = PBXBuildFile; productRef = 8090E267296775BE003106B9 /* Collections */; };
-		809874AC294BB37A00EC541E /* DevicesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809874AB294BB37A00EC541E /* DevicesTab.swift */; };
-		809BD035290C3A5200FD4043 /* DeviceManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809BD034290C3A5200FD4043 /* DeviceManager.swift */; };
-		809BD03E290CA40900FD4043 /* DeviceSelectionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809BD03D290CA40900FD4043 /* DeviceSelectionManager.swift */; };
-		809C8571297B056F004CE6A2 /* LaunchAppAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809C8570297B056F004CE6A2 /* LaunchAppAction.swift */; };
-		809C8573297B0625004CE6A2 /* LaunchFromLocationMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809C8572297B0625004CE6A2 /* LaunchFromLocationMenuItem.swift */; };
-		809C8575297B0FA9004CE6A2 /* ShowingAdvancedOptionsViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 809C8574297B0FA9004CE6A2 /* ShowingAdvancedOptionsViewModifier.swift */; };
-		80A66D6C2981BC9900ECBCB6 /* PrepareDeviceAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A66D692981BC9900ECBCB6 /* PrepareDeviceAction.swift */; };
-		80A66D6D2981BC9900ECBCB6 /* ErrorNotifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A66D6A2981BC9900ECBCB6 /* ErrorNotifier.swift */; };
-		80A66D6E2981BC9900ECBCB6 /* MirrorDeviceDisplayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A66D6B2981BC9900ECBCB6 /* MirrorDeviceDisplayAction.swift */; };
-		80A66D742981BD2200ECBCB6 /* UtilityPathPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A66D732981BD2200ECBCB6 /* UtilityPathPreferences.swift */; };
-		80A91A0D2981B9F900D8A8B9 /* ShowingAlternateItemsViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A91A0C2981B9F900D8A8B9 /* ShowingAlternateItemsViewModifier.swift */; };
-		80A91A122981BA1300D8A8B9 /* CustomWindowPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A91A0F2981BA1300D8A8B9 /* CustomWindowPresentation.swift */; };
-		80A91A132981BA1300D8A8B9 /* FloatingPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A91A102981BA1300D8A8B9 /* FloatingPanel.swift */; };
-		80A91A142981BA1300D8A8B9 /* FloatingPanelViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A91A112981BA1300D8A8B9 /* FloatingPanelViewModifier.swift */; };
-		80A91A162981BA2D00D8A8B9 /* LaunchFromURLPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A91A152981BA2D00D8A8B9 /* LaunchFromURLPanel.swift */; };
-		80AE75E42CF4F467000923E3 /* QuickLaunchEntryRecipe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AE75E32CF4F459000923E3 /* QuickLaunchEntryRecipe.swift */; };
-		80AE75E62CF4F660000923E3 /* QuickLaunchEntryRecipeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AE75E52CF4F657000923E3 /* QuickLaunchEntryRecipeSheet.swift */; };
-		80AE75E82CF50ABF000923E3 /* FormFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80AE75E72CF50ABD000923E3 /* FormFooterView.swift */; };
-		80B48DE72C8BCBA300897317 /* com.shopify.Tophat.extension.appextensionpoint in Resources */ = {isa = PBXBuildFile; fileRef = 80B48DE62C8BCBA300897317 /* com.shopify.Tophat.extension.appextensionpoint */; };
-		80B48DE92C8BCBC400897317 /* com.shopify.Tophat.extension.appextensionpoint in CopyFiles */ = {isa = PBXBuildFile; fileRef = 80B48DE62C8BCBA300897317 /* com.shopify.Tophat.extension.appextensionpoint */; };
-		80B48E132C8BD1D500897317 /* ArtifactRetrievalCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B48E122C8BD1D500897317 /* ArtifactRetrievalCoordinator.swift */; };
-		80B536052AB5407700EEB2EF /* SettingsLinkAdditionalActionButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B536042AB5407700EEB2EF /* SettingsLinkAdditionalActionButtonStyle.swift */; };
-		80B7BAD329762C0800267C3C /* InlineButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAD229762C0800267C3C /* InlineButtonStyle.swift */; };
-		80B7BAD529762CBB00267C3C /* QuickLaunchEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAD429762CBB00267C3C /* QuickLaunchEmptyState.swift */; };
-		80B7BAD729762D8900267C3C /* NSApplication+ShowSettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAD629762D8900267C3C /* NSApplication+ShowSettingsWindow.swift */; };
-		80B7BADB2976467400267C3C /* SymbolChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BADA2976467400267C3C /* SymbolChip.swift */; };
-		80B7BAE129770C5800267C3C /* LocationsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAE029770C5800267C3C /* LocationsTab.swift */; };
-		80B7BAE429773B0C00267C3C /* JavaHomePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAE329773B0C00267C3C /* JavaHomePicker.swift */; };
-		80B7BAE629773C3D00267C3C /* LocationDetectModePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAE529773C3D00267C3C /* LocationDetectModePicker.swift */; };
-		80B7BAE829773E5100267C3C /* AndroidSDKPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAE729773E5100267C3C /* AndroidSDKPicker.swift */; };
-		80B7BAEA29773EA600267C3C /* ScreenCopyPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAE929773EA600267C3C /* ScreenCopyPicker.swift */; };
-		80B7BAEC297744B500267C3C /* LocationPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B7BAEB297744B500267C3C /* LocationPicker.swift */; };
 		80C18345290232D1008D3B80 /* TophatFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 80C18344290232D1008D3B80 /* TophatFoundation */; };
-		80CBACEE298988B700F778DD /* LaunchAtLoginController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBACED298988B700F778DD /* LaunchAtLoginController.swift */; };
-		80CBACF229898FFE00F778DD /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBACF129898FFE00F778DD /* AboutView.swift */; };
-		80CBACF6298991CE00F778DD /* AboutWindowViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBACF5298991CE00F778DD /* AboutWindowViewModifier.swift */; };
-		80CBACF72989921800F778DD /* AboutWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBACF029898F9A00F778DD /* AboutWindow.swift */; };
-		80CBACFF2989B8B100F778DD /* ShowOnboardingWindowAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80CBACFE2989B8B100F778DD /* ShowOnboardingWindowAction.swift */; };
 		80D2799829005DD000F03649 /* TophatServer in Frameworks */ = {isa = PBXBuildFile; productRef = 80D2799729005DD000F03649 /* TophatServer */; };
-		80D648442CAE254300135729 /* InstallationTicketMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D648432CAE254000135729 /* InstallationTicketMachine.swift */; };
 		80D648552CB0E20C00135729 /* TophatCoreExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = 80D6484D2CB0E20C00135729 /* TophatCoreExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
-		80D71F1C2984CE720006E1BF /* XcodeOnboardingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F1B2984CE720006E1BF /* XcodeOnboardingItem.swift */; };
-		80D71F1E2984CE850006E1BF /* AndroidStudioOnboardingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F1D2984CE850006E1BF /* AndroidStudioOnboardingItem.swift */; };
-		80D71F222984CEBD0006E1BF /* CommandLineHelperOnboardingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F212984CEBD0006E1BF /* CommandLineHelperOnboardingItem.swift */; };
-		80D71F242984CEF40006E1BF /* OnboardingItemStatusIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F232984CEF40006E1BF /* OnboardingItemStatusIcon.swift */; };
-		80D71F262984CF100006E1BF /* OnboardingItemLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F252984CF100006E1BF /* OnboardingItemLayout.swift */; };
-		80D71F282984CF240006E1BF /* OnboardingTaskList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F272984CF240006E1BF /* OnboardingTaskList.swift */; };
-		80D71F2A2985C4EE0006E1BF /* ScreenCopyOnboardingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F292985C4EE0006E1BF /* ScreenCopyOnboardingItem.swift */; };
-		80D71F2C2985C69B0006E1BF /* OnboardingPopoverContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F2B2985C69B0006E1BF /* OnboardingPopoverContent.swift */; };
-		80D71F2E2985D11A0006E1BF /* CustomizeLocationsButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80D71F2D2985D11A0006E1BF /* CustomizeLocationsButton.swift */; };
 		80DC0FD82C82225600E5C9EE /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = 80DC0FD72C82225600E5C9EE /* Sparkle */; };
-		80DC0FDA2C822E7F00E5C9EE /* UpdateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80DC0FD92C822E7F00E5C9EE /* UpdateController.swift */; };
-		80EB5D47296F59270011DE5F /* PrepareDeviceTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D46296F59270011DE5F /* PrepareDeviceTask.swift */; };
-		80EB5D49296F5AAF0011DE5F /* InstallApplicationTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D48296F5AAF0011DE5F /* InstallApplicationTask.swift */; };
-		80EB5D4B296F64D70011DE5F /* DeviceError+LocalizedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D4A296F64D70011DE5F /* DeviceError+LocalizedError.swift */; };
-		80EB5D4D296F64F50011DE5F /* ApplicationError+LocalizedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D4C296F64F50011DE5F /* ApplicationError+LocalizedError.swift */; };
-		80EB5D4F296F658E0011DE5F /* InstallationTicketMachineError+LocalizedError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D4E296F658E0011DE5F /* InstallationTicketMachineError+LocalizedError.swift */; };
-		80EB5D51296F68CD0011DE5F /* OperationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D50296F68CD0011DE5F /* OperationContext.swift */; };
-		80EB5D53296F6A380011DE5F /* Array+JoinedWithSpaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D52296F6A380011DE5F /* Array+JoinedWithSpaces.swift */; };
-		80EB5D55297095890011DE5F /* TaskStatusMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D54297095890011DE5F /* TaskStatusMetadata.swift */; };
-		80EB5D57297096FB0011DE5F /* InstallStatusMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EB5D56297096FB0011DE5F /* InstallStatusMetadata.swift */; };
-		80ED3E5E29835AAF00A734B7 /* URL+ExpressibleByArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ED3E5C29835A9900A734B7 /* URL+ExpressibleByArgument.swift */; };
-		80ED55462971CB3200B3AEBA /* MirrorDeviceDisplayTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ED55452971CB3200B3AEBA /* MirrorDeviceDisplayTask.swift */; };
-		80F380432984226800A9350F /* NotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F380422984226800A9350F /* NotificationHandler.swift */; };
-		80F3804829843A9200A9350F /* Platform+ExpressibleByArgument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F3804629843A9000A9350F /* Platform+ExpressibleByArgument.swift */; };
-		80F3804929843A9F00A9350F /* Install.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F3804429843A8100A9350F /* Install.swift */; };
 		80F74E252909E8EA0040F026 /* AppleDeviceKit in Frameworks */ = {isa = PBXBuildFile; productRef = 80F74E242909E8EA0040F026 /* AppleDeviceKit */; };
-		80F74E272909FA1B0040F026 /* TophatApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F74E262909FA1B0040F026 /* TophatApp.swift */; };
-		80F74E2A2909FAC80040F026 /* MainMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F74E292909FAC80040F026 /* MainMenu.swift */; };
-		80FAC08A2AB29665004A8DB8 /* DeviceError+StyledAlertError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FAC0892AB29665004A8DB8 /* DeviceError+StyledAlertError.swift */; };
-		80FDFDB52947D4D9000606AC /* DeviceItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FDFDB42947D4D9000606AC /* DeviceItem.swift */; };
-		80FF03EF29087473008509E0 /* InstallCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80FF03EE29087473008509E0 /* InstallCoordinator.swift */; };
 		B6AA44CF296DF8EF0017321C /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = B6AA44CE296DF8EF0017321C /* ZIPFoundation */; };
-		B6AA44DD296F78670017321C /* GeneralTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6AA44DC296F78670017321C /* GeneralTab.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -231,7 +92,6 @@
 			files = (
 				808C6E3A2CF8D81F0030359E /* TophatBitriseExtension.appex in CopyFiles */,
 				80D648552CB0E20C00135729 /* TophatCoreExtension.appex in CopyFiles */,
-				80B48DE92C8BCBC400897317 /* com.shopify.Tophat.extension.appextensionpoint in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -248,158 +108,30 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		6038B795B47D50A397AF03DB /* Notifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Notifications.swift; sourceTree = "<group>"; };
 		7F35024F24A5060500EE76EA /* Tophat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tophat.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		7F35025624A5060600EE76EA /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		7F35025E24A5060600EE76EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		7F35025F24A5060600EE76EA /* Tophat.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Tophat.entitlements; sourceTree = "<group>"; };
 		7F35026424A5060600EE76EA /* TophatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TophatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		7F35026824A5060700EE76EA /* TophatTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TophatTests.swift; sourceTree = "<group>"; };
-		7F35026A24A5060700EE76EA /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8005282D2CB7185E00226174 /* TophatKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = TophatKit; sourceTree = "<group>"; };
-		8006E7E02943C9190089805E /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
-		8006E7E22943C95D0089805E /* MenuItemButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemButtonStyle.swift; sourceTree = "<group>"; };
-		8006E7E42943C9970089805E /* SectionHeadingTextStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionHeadingTextStyle.swift; sourceTree = "<group>"; };
-		8006E7E62943C9AA0089805E /* ToggleableRowIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleableRowIcon.swift; sourceTree = "<group>"; };
-		8006E7E82943C9B80089805E /* ToggleableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleableRow.swift; sourceTree = "<group>"; };
-		8006E7EC2943CA250089805E /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panel.swift; sourceTree = "<group>"; };
-		8020A6DD297F301700FEA490 /* URLReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLReader.swift; sourceTree = "<group>"; };
-		8025A5B329845EB5007B1BA0 /* Apps.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Apps.swift; sourceTree = "<group>"; };
-		802671442947C297001A804D /* MenuHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuHeader.swift; sourceTree = "<group>"; };
-		802671462947C33C001A804D /* Bundle+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extensions.swift"; sourceTree = "<group>"; };
-		802671482947C72C001A804D /* QuickLaunchEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchEntryView.swift; sourceTree = "<group>"; };
-		8026714A2947C770001A804D /* QuickLaunchPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchPanel.swift; sourceTree = "<group>"; };
-		8029A080298AF1E90002C579 /* ApplicationIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationIcon.swift; sourceTree = "<group>"; };
-		8029B6A42AC239E000BD1D30 /* DeviceIsLockedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIsLockedView.swift; sourceTree = "<group>"; };
-		8029B6A62AC239FE00BD1D30 /* DeviceIsLockedViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceIsLockedViewModifier.swift; sourceTree = "<group>"; };
-		8030161F292874B70016F25E /* ArtifactUnpacker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactUnpacker.swift; sourceTree = "<group>"; };
-		80301625292C17560016F25E /* AppleApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleApplication.swift; sourceTree = "<group>"; };
-		80301627292C17700016F25E /* AndroidApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndroidApplication.swift; sourceTree = "<group>"; };
-		8030162B292C1B490016F25E /* ApplicationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationError.swift; sourceTree = "<group>"; };
-		80343E462CA39A1A00642D54 /* ExtensionsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionsTab.swift; sourceTree = "<group>"; };
-		80462F8E2CEFA77E002F6E8F /* InfoButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoButton.swift; sourceTree = "<group>"; };
-		80462F902CEFA7EF002F6E8F /* ParameterTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterTextField.swift; sourceTree = "<group>"; };
-		80462F932CEFEF17002F6E8F /* TophatExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TophatExtension.swift; sourceTree = "<group>"; };
-		80462F962CEFEF70002F6E8F /* ExtensionHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionHost.swift; sourceTree = "<group>"; };
-		80462F982CEFF04A002F6E8F /* AppExtensionIdentity+WithXPCSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppExtensionIdentity+WithXPCSession.swift"; sourceTree = "<group>"; };
-		8046321E2CF106C9002F6E8F /* QuickLaunchEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchEntry.swift; sourceTree = "<group>"; };
-		804ECB7B2975C15300DE78F4 /* DevicePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicePicker.swift; sourceTree = "<group>"; };
-		804ECB7D2975C18300DE78F4 /* DeviceMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceMenu.swift; sourceTree = "<group>"; };
-		804ECB7F2975C68400DE78F4 /* VisibleWhenButtonHoveredViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VisibleWhenButtonHoveredViewModifier.swift; sourceTree = "<group>"; };
-		804F37F82C7CE46F0005A869 /* HostTrustResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostTrustResult.swift; sourceTree = "<group>"; };
-		804F37FC2C7CEFB00005A869 /* TrustedHostAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrustedHostAlert.swift; sourceTree = "<group>"; };
-		804FF6582914239800147652 /* Collection+Filter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Filter.swift"; sourceTree = "<group>"; };
-		80518F4D29845FB100FB8803 /* Apps+Add.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Apps+Add.swift"; sourceTree = "<group>"; };
-		80518F502984681200FB8803 /* Apps+Remove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Apps+Remove.swift"; sourceTree = "<group>"; };
-		80518F5229846E4300FB8803 /* NSRunningApplication+IsTophatRunning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRunningApplication+IsTophatRunning.swift"; sourceTree = "<group>"; };
-		80518F562984804C00FB8803 /* TophatCtlSymbolicLinkManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TophatCtlSymbolicLinkManager.swift; sourceTree = "<group>"; };
-		80518F622984A64F00FB8803 /* OnboardingWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingWindow.swift; sourceTree = "<group>"; };
-		80518F672984A6BF00FB8803 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
-		80564B5129834137002DC136 /* TaskStatusReporterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStatusReporterDelegate.swift; sourceTree = "<group>"; };
-		80564B532983414D002DC136 /* AlertOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertOptions.swift; sourceTree = "<group>"; };
-		80564B5529834203002DC136 /* FileTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTypes.swift; sourceTree = "<group>"; };
-		8058B48B2CA630620075D38D /* URLReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLReaderTests.swift; sourceTree = "<group>"; };
-		805AFDA92CF67D4900B3E227 /* ArtifactContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactContainer.swift; sourceTree = "<group>"; };
-		805AFDAB2CF6BB8900B3E227 /* CachingApplicationDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CachingApplicationDownloader.swift; sourceTree = "<group>"; };
-		805AFDAD2CF6C21F00B3E227 /* InstallSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallSession.swift; sourceTree = "<group>"; };
-		805FC43129E9BE0A00A78208 /* ArtifactDownloaderError+LocalizedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ArtifactDownloaderError+LocalizedError.swift"; sourceTree = "<group>"; };
-		80629BE92939818C0077960E /* SettingsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		80629BEC2939818C0077960E /* QuickLaunchEntryRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickLaunchEntryRow.swift; sourceTree = "<group>"; };
-		80629BED2939818C0077960E /* List+GradientButtons.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "List+GradientButtons.swift"; sourceTree = "<group>"; };
-		80629BEE2939818C0077960E /* QuickLaunchEntrySheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = QuickLaunchEntrySheet.swift; sourceTree = "<group>"; };
-		80629BEF2939818C0077960E /* AppsTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppsTab.swift; sourceTree = "<group>"; };
-		80629BF02939818C0077960E /* GradientButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GradientButton.swift; sourceTree = "<group>"; };
-		80629BF72939819F0077960E /* String+IsValidURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+IsValidURL.swift"; sourceTree = "<group>"; };
-		80629BFB293981B10077960E /* CodableAppStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodableAppStorage.swift; sourceTree = "<group>"; };
-		80629C21293A8D270077960E /* ProvisioningProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProvisioningProfile.swift; sourceTree = "<group>"; };
-		80691D272CDA9ADE006572CD /* ArtifactDownloader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDownloader.swift; sourceTree = "<group>"; wrapsLines = 0; };
-		8079E3552C850FE0000CB5B3 /* View+ShowDockIconWhenOpen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ShowDockIconWhenOpen.swift"; sourceTree = "<group>"; };
 		807D7B0729835756007942B4 /* tophatctl */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tophatctl; sourceTree = BUILT_PRODUCTS_DIR; };
-		807D7B102983576C007942B4 /* TophatCtl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TophatCtl.swift; sourceTree = "<group>"; };
 		8086AE3628F9E8680069217E /* TophatModules */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = TophatModules; sourceTree = "<group>"; };
 		808C6E322CF8D81F0030359E /* TophatBitriseExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = TophatBitriseExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		8090E2022950C1CC003106B9 /* CollapsibleSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleSection.swift; sourceTree = "<group>"; };
-		8090E2122950E01E003106B9 /* DeviceList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceList.swift; sourceTree = "<group>"; };
-		8090E2562967741F003106B9 /* TaskProgress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskProgress.swift; sourceTree = "<group>"; };
-		8090E2572967741F003106B9 /* TaskState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskState.swift; sourceTree = "<group>"; };
-		8090E2582967741F003106B9 /* TaskStatusReporter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskStatusReporter.swift; sourceTree = "<group>"; };
-		8090E2592967741F003106B9 /* TaskStatus.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskStatus.swift; sourceTree = "<group>"; };
-		8090E25E29677489003106B9 /* MainProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainProgressView.swift; sourceTree = "<group>"; };
-		8090E2602967749F003106B9 /* TophatProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TophatProgressViewStyle.swift; sourceTree = "<group>"; };
-		8090E262296774C1003106B9 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
-		8090E264296774D2003106B9 /* StatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusPopover.swift; sourceTree = "<group>"; };
-		809874AB294BB37A00EC541E /* DevicesTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DevicesTab.swift; sourceTree = "<group>"; };
-		809BD034290C3A5200FD4043 /* DeviceManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceManager.swift; sourceTree = "<group>"; };
-		809BD03D290CA40900FD4043 /* DeviceSelectionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceSelectionManager.swift; sourceTree = "<group>"; };
-		809C8570297B056F004CE6A2 /* LaunchAppAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAppAction.swift; sourceTree = "<group>"; };
-		809C8572297B0625004CE6A2 /* LaunchFromLocationMenuItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchFromLocationMenuItem.swift; sourceTree = "<group>"; };
-		809C8574297B0FA9004CE6A2 /* ShowingAdvancedOptionsViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowingAdvancedOptionsViewModifier.swift; sourceTree = "<group>"; };
-		80A66D692981BC9900ECBCB6 /* PrepareDeviceAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrepareDeviceAction.swift; sourceTree = "<group>"; };
-		80A66D6A2981BC9900ECBCB6 /* ErrorNotifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ErrorNotifier.swift; sourceTree = "<group>"; };
-		80A66D6B2981BC9900ECBCB6 /* MirrorDeviceDisplayAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MirrorDeviceDisplayAction.swift; sourceTree = "<group>"; };
-		80A66D732981BD2200ECBCB6 /* UtilityPathPreferences.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UtilityPathPreferences.swift; sourceTree = "<group>"; };
-		80A91A0C2981B9F900D8A8B9 /* ShowingAlternateItemsViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShowingAlternateItemsViewModifier.swift; sourceTree = "<group>"; };
-		80A91A0F2981BA1300D8A8B9 /* CustomWindowPresentation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomWindowPresentation.swift; sourceTree = "<group>"; };
-		80A91A102981BA1300D8A8B9 /* FloatingPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPanel.swift; sourceTree = "<group>"; };
-		80A91A112981BA1300D8A8B9 /* FloatingPanelViewModifier.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatingPanelViewModifier.swift; sourceTree = "<group>"; };
-		80A91A152981BA2D00D8A8B9 /* LaunchFromURLPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LaunchFromURLPanel.swift; sourceTree = "<group>"; };
-		80AE75E32CF4F459000923E3 /* QuickLaunchEntryRecipe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchEntryRecipe.swift; sourceTree = "<group>"; };
-		80AE75E52CF4F657000923E3 /* QuickLaunchEntryRecipeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchEntryRecipeSheet.swift; sourceTree = "<group>"; };
-		80AE75E72CF50ABD000923E3 /* FormFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormFooterView.swift; sourceTree = "<group>"; };
-		80B48DE62C8BCBA300897317 /* com.shopify.Tophat.extension.appextensionpoint */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = com.shopify.Tophat.extension.appextensionpoint; sourceTree = "<group>"; };
-		80B48E122C8BD1D500897317 /* ArtifactRetrievalCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactRetrievalCoordinator.swift; sourceTree = "<group>"; };
-		80B536042AB5407700EEB2EF /* SettingsLinkAdditionalActionButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLinkAdditionalActionButtonStyle.swift; sourceTree = "<group>"; };
-		80B7BAD229762C0800267C3C /* InlineButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineButtonStyle.swift; sourceTree = "<group>"; };
-		80B7BAD429762CBB00267C3C /* QuickLaunchEmptyState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLaunchEmptyState.swift; sourceTree = "<group>"; };
-		80B7BAD629762D8900267C3C /* NSApplication+ShowSettingsWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSApplication+ShowSettingsWindow.swift"; sourceTree = "<group>"; };
-		80B7BADA2976467400267C3C /* SymbolChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SymbolChip.swift; sourceTree = "<group>"; };
-		80B7BAE029770C5800267C3C /* LocationsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationsTab.swift; sourceTree = "<group>"; };
-		80B7BAE329773B0C00267C3C /* JavaHomePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JavaHomePicker.swift; sourceTree = "<group>"; };
-		80B7BAE529773C3D00267C3C /* LocationDetectModePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationDetectModePicker.swift; sourceTree = "<group>"; };
-		80B7BAE729773E5100267C3C /* AndroidSDKPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndroidSDKPicker.swift; sourceTree = "<group>"; };
-		80B7BAE929773EA600267C3C /* ScreenCopyPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCopyPicker.swift; sourceTree = "<group>"; };
-		80B7BAEB297744B500267C3C /* LocationPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationPicker.swift; sourceTree = "<group>"; };
-		80CBACED298988B700F778DD /* LaunchAtLoginController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchAtLoginController.swift; sourceTree = "<group>"; };
-		80CBACF029898F9A00F778DD /* AboutWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutWindow.swift; sourceTree = "<group>"; };
-		80CBACF129898FFE00F778DD /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
-		80CBACF5298991CE00F778DD /* AboutWindowViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutWindowViewModifier.swift; sourceTree = "<group>"; };
-		80CBACFE2989B8B100F778DD /* ShowOnboardingWindowAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowOnboardingWindowAction.swift; sourceTree = "<group>"; };
-		80D648432CAE254000135729 /* InstallationTicketMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallationTicketMachine.swift; sourceTree = "<group>"; };
 		80D6484D2CB0E20C00135729 /* TophatCoreExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = TophatCoreExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
-		80D71F1B2984CE720006E1BF /* XcodeOnboardingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XcodeOnboardingItem.swift; sourceTree = "<group>"; };
-		80D71F1D2984CE850006E1BF /* AndroidStudioOnboardingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AndroidStudioOnboardingItem.swift; sourceTree = "<group>"; };
-		80D71F212984CEBD0006E1BF /* CommandLineHelperOnboardingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandLineHelperOnboardingItem.swift; sourceTree = "<group>"; };
-		80D71F232984CEF40006E1BF /* OnboardingItemStatusIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingItemStatusIcon.swift; sourceTree = "<group>"; };
-		80D71F252984CF100006E1BF /* OnboardingItemLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingItemLayout.swift; sourceTree = "<group>"; };
-		80D71F272984CF240006E1BF /* OnboardingTaskList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTaskList.swift; sourceTree = "<group>"; };
-		80D71F292985C4EE0006E1BF /* ScreenCopyOnboardingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCopyOnboardingItem.swift; sourceTree = "<group>"; };
-		80D71F2B2985C69B0006E1BF /* OnboardingPopoverContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPopoverContent.swift; sourceTree = "<group>"; };
-		80D71F2D2985D11A0006E1BF /* CustomizeLocationsButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeLocationsButton.swift; sourceTree = "<group>"; };
-		80DC0FD52C82202600E5C9EE /* TophatCtl.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TophatCtl.entitlements; sourceTree = "<group>"; };
-		80DC0FD92C822E7F00E5C9EE /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
-		80EB5D46296F59270011DE5F /* PrepareDeviceTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepareDeviceTask.swift; sourceTree = "<group>"; };
-		80EB5D48296F5AAF0011DE5F /* InstallApplicationTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallApplicationTask.swift; sourceTree = "<group>"; };
-		80EB5D4A296F64D70011DE5F /* DeviceError+LocalizedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceError+LocalizedError.swift"; sourceTree = "<group>"; };
-		80EB5D4C296F64F50011DE5F /* ApplicationError+LocalizedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ApplicationError+LocalizedError.swift"; sourceTree = "<group>"; };
-		80EB5D4E296F658E0011DE5F /* InstallationTicketMachineError+LocalizedError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InstallationTicketMachineError+LocalizedError.swift"; sourceTree = "<group>"; };
-		80EB5D50296F68CD0011DE5F /* OperationContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OperationContext.swift; sourceTree = "<group>"; };
-		80EB5D52296F6A380011DE5F /* Array+JoinedWithSpaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+JoinedWithSpaces.swift"; sourceTree = "<group>"; };
-		80EB5D54297095890011DE5F /* TaskStatusMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskStatusMetadata.swift; sourceTree = "<group>"; };
-		80EB5D56297096FB0011DE5F /* InstallStatusMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallStatusMetadata.swift; sourceTree = "<group>"; };
-		80ED3E5C29835A9900A734B7 /* URL+ExpressibleByArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+ExpressibleByArgument.swift"; sourceTree = "<group>"; };
-		80ED55452971CB3200B3AEBA /* MirrorDeviceDisplayTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MirrorDeviceDisplayTask.swift; sourceTree = "<group>"; };
-		80F380422984226800A9350F /* NotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationHandler.swift; sourceTree = "<group>"; };
-		80F3804429843A8100A9350F /* Install.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Install.swift; sourceTree = "<group>"; };
-		80F3804629843A9000A9350F /* Platform+ExpressibleByArgument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Platform+ExpressibleByArgument.swift"; sourceTree = "<group>"; };
-		80F74E262909FA1B0040F026 /* TophatApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TophatApp.swift; sourceTree = "<group>"; };
-		80F74E292909FAC80040F026 /* MainMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainMenu.swift; sourceTree = "<group>"; };
-		80FAC0892AB29665004A8DB8 /* DeviceError+StyledAlertError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DeviceError+StyledAlertError.swift"; sourceTree = "<group>"; };
-		80FDFDB42947D4D9000606AC /* DeviceItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceItem.swift; sourceTree = "<group>"; };
-		80FF03EE29087473008509E0 /* InstallCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstallCoordinator.swift; sourceTree = "<group>"; wrapsLines = 1; };
-		B6AA44DC296F78670017321C /* GeneralTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralTab.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		8001A5962CFE293D00325E7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7F35024E24A5060500EE76EA /* Tophat */;
+		};
+		8001A5A02CFE294100325E7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7F35026324A5060600EE76EA /* TophatTests */;
+		};
 		808C6E442CF8D8260030359E /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -433,7 +165,20 @@
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		8001A5972CFE293D00325E7B /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = 80B48DE82C8BCBBE00897317 /* CopyFiles */;
+			membershipExceptions = (
+				com.shopify.Tophat.extension.appextensionpoint,
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
+		8001A5132CFE293D00325E7B /* Tophat */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (8001A5962CFE293D00325E7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 8001A5972CFE293D00325E7B /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = Tophat; sourceTree = "<group>"; };
+		8001A59C2CFE294100325E7B /* TophatTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (8001A5A02CFE294100325E7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TophatTests; sourceTree = "<group>"; };
+		8001A5AD2CFE294400325E7B /* TophatCtl */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TophatCtl; sourceTree = "<group>"; };
 		80D648482CB0E1C200135729 /* TophatExtensions */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (80D6485F2CB0E22200135729 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 808C6E442CF8D8260030359E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TophatExtensions; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
@@ -499,14 +244,13 @@
 		7F35024624A5060500EE76EA = {
 			isa = PBXGroup;
 			children = (
-				7F35025124A5060500EE76EA /* Tophat */,
-				7F35026724A5060700EE76EA /* TophatTests */,
-				807D7B0829835756007942B4 /* TophatCtl */,
+				8001A5132CFE293D00325E7B /* Tophat */,
+				8001A59C2CFE294100325E7B /* TophatTests */,
+				8001A5AD2CFE294400325E7B /* TophatCtl */,
 				8086AE3628F9E8680069217E /* TophatModules */,
 				8005282D2CB7185E00226174 /* TophatKit */,
 				80D648482CB0E1C200135729 /* TophatExtensions */,
 				7F35025024A5060500EE76EA /* Products */,
-				8086AE3728F9F01F0069217E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -520,320 +264,6 @@
 				808C6E322CF8D81F0030359E /* TophatBitriseExtension.appex */,
 			);
 			name = Products;
-			sourceTree = "<group>";
-		};
-		7F35025124A5060500EE76EA /* Tophat */ = {
-			isa = PBXGroup;
-			children = (
-				804FF6572914237D00147652 /* Extensions */,
-				80301629292C19E10016F25E /* Models */,
-				80FF03ED29087440008509E0 /* Utilities */,
-				80F74E282909FA9B0040F026 /* Views */,
-				7F35025624A5060600EE76EA /* Assets.xcassets */,
-				7F35025E24A5060600EE76EA /* Info.plist */,
-				7F35025F24A5060600EE76EA /* Tophat.entitlements */,
-				80B48DE62C8BCBA300897317 /* com.shopify.Tophat.extension.appextensionpoint */,
-				80F74E262909FA1B0040F026 /* TophatApp.swift */,
-			);
-			path = Tophat;
-			sourceTree = "<group>";
-		};
-		7F35026724A5060700EE76EA /* TophatTests */ = {
-			isa = PBXGroup;
-			children = (
-				8058B48A2CA6304C0075D38D /* Utilities */,
-				7F35026824A5060700EE76EA /* TophatTests.swift */,
-				7F35026A24A5060700EE76EA /* Info.plist */,
-			);
-			path = TophatTests;
-			sourceTree = "<group>";
-		};
-		80301629292C19E10016F25E /* Models */ = {
-			isa = PBXGroup;
-			children = (
-				80301627292C17700016F25E /* AndroidApplication.swift */,
-				80301625292C17560016F25E /* AppleApplication.swift */,
-				8030162B292C1B490016F25E /* ApplicationError.swift */,
-				8029A080298AF1E90002C579 /* ApplicationIcon.swift */,
-				80EB5D56297096FB0011DE5F /* InstallStatusMetadata.swift */,
-				80EB5D50296F68CD0011DE5F /* OperationContext.swift */,
-				80629C21293A8D270077960E /* ProvisioningProfile.swift */,
-				8046321E2CF106C9002F6E8F /* QuickLaunchEntry.swift */,
-				80AE75E32CF4F459000923E3 /* QuickLaunchEntryRecipe.swift */,
-			);
-			path = Models;
-			sourceTree = "<group>";
-		};
-		80462F952CEFEF3C002F6E8F /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				80462F982CEFF04A002F6E8F /* AppExtensionIdentity+WithXPCSession.swift */,
-				80B48E122C8BD1D500897317 /* ArtifactRetrievalCoordinator.swift */,
-				80462F962CEFEF70002F6E8F /* ExtensionHost.swift */,
-				80462F932CEFEF17002F6E8F /* TophatExtension.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		804FF6572914237D00147652 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				80EB5D4C296F64F50011DE5F /* ApplicationError+LocalizedError.swift */,
-				80EB5D52296F6A380011DE5F /* Array+JoinedWithSpaces.swift */,
-				805FC43129E9BE0A00A78208 /* ArtifactDownloaderError+LocalizedError.swift */,
-				802671462947C33C001A804D /* Bundle+Extensions.swift */,
-				804FF6582914239800147652 /* Collection+Filter.swift */,
-				80EB5D4A296F64D70011DE5F /* DeviceError+LocalizedError.swift */,
-				80FAC0892AB29665004A8DB8 /* DeviceError+StyledAlertError.swift */,
-				80EB5D4E296F658E0011DE5F /* InstallationTicketMachineError+LocalizedError.swift */,
-				80B7BAD629762D8900267C3C /* NSApplication+ShowSettingsWindow.swift */,
-				80629BF72939819F0077960E /* String+IsValidURL.swift */,
-				8079E3552C850FE0000CB5B3 /* View+ShowDockIconWhenOpen.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		80518F4C29845F9E00FB8803 /* Apps */ = {
-			isa = PBXGroup;
-			children = (
-				80518F4D29845FB100FB8803 /* Apps+Add.swift */,
-				80518F502984681200FB8803 /* Apps+Remove.swift */,
-			);
-			path = Apps;
-			sourceTree = "<group>";
-		};
-		80518F662984A6A800FB8803 /* Onboarding */ = {
-			isa = PBXGroup;
-			children = (
-				80D71F1D2984CE850006E1BF /* AndroidStudioOnboardingItem.swift */,
-				80D71F212984CEBD0006E1BF /* CommandLineHelperOnboardingItem.swift */,
-				80D71F2D2985D11A0006E1BF /* CustomizeLocationsButton.swift */,
-				80D71F252984CF100006E1BF /* OnboardingItemLayout.swift */,
-				80D71F232984CEF40006E1BF /* OnboardingItemStatusIcon.swift */,
-				80D71F2B2985C69B0006E1BF /* OnboardingPopoverContent.swift */,
-				80D71F272984CF240006E1BF /* OnboardingTaskList.swift */,
-				80518F672984A6BF00FB8803 /* OnboardingView.swift */,
-				80518F622984A64F00FB8803 /* OnboardingWindow.swift */,
-				80D71F292985C4EE0006E1BF /* ScreenCopyOnboardingItem.swift */,
-				80D71F1B2984CE720006E1BF /* XcodeOnboardingItem.swift */,
-			);
-			path = Onboarding;
-			sourceTree = "<group>";
-		};
-		8058B48A2CA6304C0075D38D /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				8058B48B2CA630620075D38D /* URLReaderTests.swift */,
-			);
-			path = Utilities;
-			sourceTree = "<group>";
-		};
-		80629BEB2939818C0077960E /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				80629BEE2939818C0077960E /* QuickLaunchEntrySheet.swift */,
-				80AE75E52CF4F657000923E3 /* QuickLaunchEntryRecipeSheet.swift */,
-				80629BEF2939818C0077960E /* AppsTab.swift */,
-				809874AB294BB37A00EC541E /* DevicesTab.swift */,
-				80343E462CA39A1A00642D54 /* ExtensionsTab.swift */,
-				B6AA44DC296F78670017321C /* GeneralTab.swift */,
-				80462F8E2CEFA77E002F6E8F /* InfoButton.swift */,
-				80B7BAE229773AFA00267C3C /* Locations */,
-				80B7BAE029770C5800267C3C /* LocationsTab.swift */,
-				80462F902CEFA7EF002F6E8F /* ParameterTextField.swift */,
-				80629BEC2939818C0077960E /* QuickLaunchEntryRow.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
-		80629BFF293989600077960E /* Generic */ = {
-			isa = PBXGroup;
-			children = (
-				80AE75E72CF50ABD000923E3 /* FormFooterView.swift */,
-				8090E2022950C1CC003106B9 /* CollapsibleSection.swift */,
-				80629BF02939818C0077960E /* GradientButton.swift */,
-				80B7BAD229762C0800267C3C /* InlineButtonStyle.swift */,
-				80629BED2939818C0077960E /* List+GradientButtons.swift */,
-				8090E25E29677489003106B9 /* MainProgressView.swift */,
-				8006E7E22943C95D0089805E /* MenuItemButtonStyle.swift */,
-				8006E7EC2943CA250089805E /* Panel.swift */,
-				8006E7E42943C9970089805E /* SectionHeadingTextStyle.swift */,
-				80B536042AB5407700EEB2EF /* SettingsLinkAdditionalActionButtonStyle.swift */,
-				809C8574297B0FA9004CE6A2 /* ShowingAdvancedOptionsViewModifier.swift */,
-				80A91A0C2981B9F900D8A8B9 /* ShowingAlternateItemsViewModifier.swift */,
-				80B7BADA2976467400267C3C /* SymbolChip.swift */,
-				8006E7E82943C9B80089805E /* ToggleableRow.swift */,
-				8006E7E62943C9AA0089805E /* ToggleableRowIcon.swift */,
-				8090E2602967749F003106B9 /* TophatProgressViewStyle.swift */,
-				804ECB7F2975C68400DE78F4 /* VisibleWhenButtonHoveredViewModifier.swift */,
-			);
-			path = Generic;
-			sourceTree = "<group>";
-		};
-		807D7B0829835756007942B4 /* TophatCtl */ = {
-			isa = PBXGroup;
-			children = (
-				807D7B112983576C007942B4 /* Commands */,
-				80ED3E5B29835A8900A734B7 /* Extensions */,
-				80DC0FD52C82202600E5C9EE /* TophatCtl.entitlements */,
-				807D7B102983576C007942B4 /* TophatCtl.swift */,
-			);
-			path = TophatCtl;
-			sourceTree = "<group>";
-		};
-		807D7B112983576C007942B4 /* Commands */ = {
-			isa = PBXGroup;
-			children = (
-				80518F4C29845F9E00FB8803 /* Apps */,
-				8025A5B329845EB5007B1BA0 /* Apps.swift */,
-				80F3804429843A8100A9350F /* Install.swift */,
-			);
-			path = Commands;
-			sourceTree = "<group>";
-		};
-		8086AE3728F9F01F0069217E /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		8090E2552967741F003106B9 /* Status Reporting */ = {
-			isa = PBXGroup;
-			children = (
-				80564B532983414D002DC136 /* AlertOptions.swift */,
-				8090E2562967741F003106B9 /* TaskProgress.swift */,
-				8090E2572967741F003106B9 /* TaskState.swift */,
-				8090E2592967741F003106B9 /* TaskStatus.swift */,
-				80EB5D54297095890011DE5F /* TaskStatusMetadata.swift */,
-				8090E2582967741F003106B9 /* TaskStatusReporter.swift */,
-				80564B5129834137002DC136 /* TaskStatusReporterDelegate.swift */,
-			);
-			path = "Status Reporting";
-			sourceTree = "<group>";
-		};
-		80A91A0E2981BA1300D8A8B9 /* Windows */ = {
-			isa = PBXGroup;
-			children = (
-				80A91A0F2981BA1300D8A8B9 /* CustomWindowPresentation.swift */,
-				80A91A102981BA1300D8A8B9 /* FloatingPanel.swift */,
-				80A91A112981BA1300D8A8B9 /* FloatingPanelViewModifier.swift */,
-			);
-			path = Windows;
-			sourceTree = "<group>";
-		};
-		80B7BAE229773AFA00267C3C /* Locations */ = {
-			isa = PBXGroup;
-			children = (
-				80B7BAE729773E5100267C3C /* AndroidSDKPicker.swift */,
-				80B7BAE329773B0C00267C3C /* JavaHomePicker.swift */,
-				80B7BAE529773C3D00267C3C /* LocationDetectModePicker.swift */,
-				80B7BAEB297744B500267C3C /* LocationPicker.swift */,
-				80B7BAE929773EA600267C3C /* ScreenCopyPicker.swift */,
-			);
-			path = Locations;
-			sourceTree = "<group>";
-		};
-		80CBACEF29898F6D00F778DD /* About */ = {
-			isa = PBXGroup;
-			children = (
-				80CBACF029898F9A00F778DD /* AboutWindow.swift */,
-				80CBACF129898FFE00F778DD /* AboutView.swift */,
-				80CBACF5298991CE00F778DD /* AboutWindowViewModifier.swift */,
-			);
-			path = About;
-			sourceTree = "<group>";
-		};
-		80EB5D43296F59000011DE5F /* Tasks */ = {
-			isa = PBXGroup;
-			children = (
-				80EB5D48296F5AAF0011DE5F /* InstallApplicationTask.swift */,
-				80ED55452971CB3200B3AEBA /* MirrorDeviceDisplayTask.swift */,
-				80EB5D46296F59270011DE5F /* PrepareDeviceTask.swift */,
-			);
-			path = Tasks;
-			sourceTree = "<group>";
-		};
-		80ED3E5B29835A8900A734B7 /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-				80518F5229846E4300FB8803 /* NSRunningApplication+IsTophatRunning.swift */,
-				80F3804629843A9000A9350F /* Platform+ExpressibleByArgument.swift */,
-				80ED3E5C29835A9900A734B7 /* URL+ExpressibleByArgument.swift */,
-			);
-			path = Extensions;
-			sourceTree = "<group>";
-		};
-		80F74E282909FA9B0040F026 /* Views */ = {
-			isa = PBXGroup;
-			children = (
-				80CBACEF29898F6D00F778DD /* About */,
-				80629BFF293989600077960E /* Generic */,
-				80518F662984A6A800FB8803 /* Onboarding */,
-				80FDFDB62947DA61000606AC /* Quick Launch */,
-				80629BEB2939818C0077960E /* Settings */,
-				80A91A0E2981BA1300D8A8B9 /* Windows */,
-				8029B6A42AC239E000BD1D30 /* DeviceIsLockedView.swift */,
-				8029B6A62AC239FE00BD1D30 /* DeviceIsLockedViewModifier.swift */,
-				80FDFDB42947D4D9000606AC /* DeviceItem.swift */,
-				8090E2122950E01E003106B9 /* DeviceList.swift */,
-				804ECB7D2975C18300DE78F4 /* DeviceMenu.swift */,
-				804ECB7B2975C15300DE78F4 /* DevicePicker.swift */,
-				809C8572297B0625004CE6A2 /* LaunchFromLocationMenuItem.swift */,
-				80A91A152981BA2D00D8A8B9 /* LaunchFromURLPanel.swift */,
-				80F74E292909FAC80040F026 /* MainMenu.swift */,
-				802671442947C297001A804D /* MenuHeader.swift */,
-				80629BE92939818C0077960E /* SettingsView.swift */,
-				8090E264296774D2003106B9 /* StatusPopover.swift */,
-				8090E262296774C1003106B9 /* StatusView.swift */,
-				8006E7E02943C9190089805E /* Theme.swift */,
-			);
-			path = Views;
-			sourceTree = "<group>";
-		};
-		80FDFDB62947DA61000606AC /* Quick Launch */ = {
-			isa = PBXGroup;
-			children = (
-				802671482947C72C001A804D /* QuickLaunchEntryView.swift */,
-				80B7BAD429762CBB00267C3C /* QuickLaunchEmptyState.swift */,
-				8026714A2947C770001A804D /* QuickLaunchPanel.swift */,
-			);
-			path = "Quick Launch";
-			sourceTree = "<group>";
-		};
-		80FF03ED29087440008509E0 /* Utilities */ = {
-			isa = PBXGroup;
-			children = (
-				80462F952CEFEF3C002F6E8F /* Extensions */,
-				8090E2552967741F003106B9 /* Status Reporting */,
-				80EB5D43296F59000011DE5F /* Tasks */,
-				805AFDA92CF67D4900B3E227 /* ArtifactContainer.swift */,
-				80691D272CDA9ADE006572CD /* ArtifactDownloader.swift */,
-				8030161F292874B70016F25E /* ArtifactUnpacker.swift */,
-				80629BFB293981B10077960E /* CodableAppStorage.swift */,
-				809BD034290C3A5200FD4043 /* DeviceManager.swift */,
-				809BD03D290CA40900FD4043 /* DeviceSelectionManager.swift */,
-				80A66D6A2981BC9900ECBCB6 /* ErrorNotifier.swift */,
-				80564B5529834203002DC136 /* FileTypes.swift */,
-				804F37F82C7CE46F0005A869 /* HostTrustResult.swift */,
-				80FF03EE29087473008509E0 /* InstallCoordinator.swift */,
-				805AFDAD2CF6C21F00B3E227 /* InstallSession.swift */,
-				805AFDAB2CF6BB8900B3E227 /* CachingApplicationDownloader.swift */,
-				80D648432CAE254000135729 /* InstallationTicketMachine.swift */,
-				809C8570297B056F004CE6A2 /* LaunchAppAction.swift */,
-				80CBACED298988B700F778DD /* LaunchAtLoginController.swift */,
-				80A66D6B2981BC9900ECBCB6 /* MirrorDeviceDisplayAction.swift */,
-				80F380422984226800A9350F /* NotificationHandler.swift */,
-				6038B795B47D50A397AF03DB /* Notifications.swift */,
-				80A66D692981BC9900ECBCB6 /* PrepareDeviceAction.swift */,
-				80CBACFE2989B8B100F778DD /* ShowOnboardingWindowAction.swift */,
-				80518F562984804C00FB8803 /* TophatCtlSymbolicLinkManager.swift */,
-				804F37FC2C7CEFB00005A869 /* TrustedHostAlert.swift */,
-				80DC0FD92C822E7F00E5C9EE /* UpdateController.swift */,
-				8020A6DD297F301700FEA490 /* URLReader.swift */,
-				80A66D732981BD2200ECBCB6 /* UtilityPathPreferences.swift */,
-			);
-			path = Utilities;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -857,6 +287,9 @@
 				807D7B18298357A7007942B4 /* PBXTargetDependency */,
 				80D648542CB0E20C00135729 /* PBXTargetDependency */,
 				808C6E392CF8D81F0030359E /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				8001A5132CFE293D00325E7B /* Tophat */,
 			);
 			name = Tophat;
 			packageProductDependencies = (
@@ -892,6 +325,9 @@
 			dependencies = (
 				7F35026624A5060600EE76EA /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				8001A59C2CFE294100325E7B /* TophatTests */,
+			);
 			name = TophatTests;
 			productName = TophatTests;
 			productReference = 7F35026424A5060600EE76EA /* TophatTests.xctest */;
@@ -908,6 +344,9 @@
 			buildRules = (
 			);
 			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				8001A5AD2CFE294400325E7B /* TophatCtl */,
 			);
 			name = tophatctl;
 			packageProductDependencies = (
@@ -968,7 +407,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1610;
-				LastUpgradeCheck = 1540;
+				LastUpgradeCheck = 1610;
 				ORGANIZATIONNAME = Shopify;
 				TargetAttributes = {
 					7F35024E24A5060500EE76EA = {
@@ -990,7 +429,6 @@
 				};
 			};
 			buildConfigurationList = 7F35024A24A5060500EE76EA /* Build configuration list for PBXProject "Tophat" */;
-			compatibilityVersion = "Xcode 9.3";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -1010,6 +448,7 @@
 				80DC0FD62C82225600E5C9EE /* XCRemoteSwiftPackageReference "Sparkle" */,
 				8001A47F2CF9275400325E7B /* XCRemoteSwiftPackageReference "SimpleKeychain" */,
 			);
+			preferredProjectObjectVersion = 50;
 			productRefGroup = 7F35025024A5060500EE76EA /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1028,8 +467,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7F35025724A5060600EE76EA /* Assets.xcassets in Resources */,
-				80B48DE72C8BCBA300897317 /* com.shopify.Tophat.extension.appextensionpoint in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1083,132 +520,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80AE75E82CF50ABF000923E3 /* FormFooterView.swift in Sources */,
-				80629BF12939818C0077960E /* SettingsView.swift in Sources */,
-				809C8573297B0625004CE6A2 /* LaunchFromLocationMenuItem.swift in Sources */,
-				80F74E2A2909FAC80040F026 /* MainMenu.swift in Sources */,
-				80A66D742981BD2200ECBCB6 /* UtilityPathPreferences.swift in Sources */,
-				805AFDAC2CF6BB8D00B3E227 /* CachingApplicationDownloader.swift in Sources */,
-				80FAC08A2AB29665004A8DB8 /* DeviceError+StyledAlertError.swift in Sources */,
-				80518F682984A6BF00FB8803 /* OnboardingView.swift in Sources */,
-				80629BF82939819F0077960E /* String+IsValidURL.swift in Sources */,
-				809874AC294BB37A00EC541E /* DevicesTab.swift in Sources */,
-				80B7BAE129770C5800267C3C /* LocationsTab.swift in Sources */,
-				80462F972CEFEF73002F6E8F /* ExtensionHost.swift in Sources */,
-				80462F942CEFEF1A002F6E8F /* TophatExtension.swift in Sources */,
-				804ECB7E2975C18300DE78F4 /* DeviceMenu.swift in Sources */,
-				80CBACFF2989B8B100F778DD /* ShowOnboardingWindowAction.swift in Sources */,
-				80F74E272909FA1B0040F026 /* TophatApp.swift in Sources */,
-				80EB5D51296F68CD0011DE5F /* OperationContext.swift in Sources */,
-				80518F572984804C00FB8803 /* TophatCtlSymbolicLinkManager.swift in Sources */,
-				80EB5D49296F5AAF0011DE5F /* InstallApplicationTask.swift in Sources */,
-				8006E7E32943C95D0089805E /* MenuItemButtonStyle.swift in Sources */,
-				8006E7E92943C9B80089805E /* ToggleableRow.swift in Sources */,
-				80D648442CAE254300135729 /* InstallationTicketMachine.swift in Sources */,
-				804F37FD2C7CEFB00005A869 /* TrustedHostAlert.swift in Sources */,
-				80CBACF229898FFE00F778DD /* AboutView.swift in Sources */,
-				80629BF52939818C0077960E /* AppsTab.swift in Sources */,
-				8046321F2CF106D5002F6E8F /* QuickLaunchEntry.swift in Sources */,
-				805AFDAA2CF67D4C00B3E227 /* ArtifactContainer.swift in Sources */,
-				80AE75E62CF4F660000923E3 /* QuickLaunchEntryRecipeSheet.swift in Sources */,
-				80D71F262984CF100006E1BF /* OnboardingItemLayout.swift in Sources */,
-				8090E25B2967741F003106B9 /* TaskState.swift in Sources */,
-				80CBACEE298988B700F778DD /* LaunchAtLoginController.swift in Sources */,
-				8090E2612967749F003106B9 /* TophatProgressViewStyle.swift in Sources */,
-				80B7BAD329762C0800267C3C /* InlineButtonStyle.swift in Sources */,
-				80EB5D47296F59270011DE5F /* PrepareDeviceTask.swift in Sources */,
-				8029B6A72AC239FE00BD1D30 /* DeviceIsLockedViewModifier.swift in Sources */,
-				80343E472CA39A1D00642D54 /* ExtensionsTab.swift in Sources */,
-				80D71F242984CEF40006E1BF /* OnboardingItemStatusIcon.swift in Sources */,
-				8090E25F29677489003106B9 /* MainProgressView.swift in Sources */,
-				804F37F92C7CE46F0005A869 /* HostTrustResult.swift in Sources */,
-				80629BFC293981B10077960E /* CodableAppStorage.swift in Sources */,
-				8026714B2947C770001A804D /* QuickLaunchPanel.swift in Sources */,
-				8090E263296774C1003106B9 /* StatusView.swift in Sources */,
-				805AFDAE2CF6C22700B3E227 /* InstallSession.swift in Sources */,
-				8090E2132950E01E003106B9 /* DeviceList.swift in Sources */,
-				809C8571297B056F004CE6A2 /* LaunchAppAction.swift in Sources */,
-				809BD03E290CA40900FD4043 /* DeviceSelectionManager.swift in Sources */,
-				80D71F282984CF240006E1BF /* OnboardingTaskList.swift in Sources */,
-				80A91A0D2981B9F900D8A8B9 /* ShowingAlternateItemsViewModifier.swift in Sources */,
-				80A91A162981BA2D00D8A8B9 /* LaunchFromURLPanel.swift in Sources */,
-				8090E2032950C1CC003106B9 /* CollapsibleSection.swift in Sources */,
-				80518F632984A64F00FB8803 /* OnboardingWindow.swift in Sources */,
-				80EB5D55297095890011DE5F /* TaskStatusMetadata.swift in Sources */,
-				80DC0FDA2C822E7F00E5C9EE /* UpdateController.swift in Sources */,
-				80D71F2E2985D11A0006E1BF /* CustomizeLocationsButton.swift in Sources */,
-				80EB5D57297096FB0011DE5F /* InstallStatusMetadata.swift in Sources */,
-				8020A6DE297F301700FEA490 /* URLReader.swift in Sources */,
-				80B7BAEC297744B500267C3C /* LocationPicker.swift in Sources */,
-				6038BC5B50B9DB89F651A6EA /* Notifications.swift in Sources */,
-				809BD035290C3A5200FD4043 /* DeviceManager.swift in Sources */,
-				80CBACF72989921800F778DD /* AboutWindow.swift in Sources */,
-				80B7BAE429773B0C00267C3C /* JavaHomePicker.swift in Sources */,
-				80B7BADB2976467400267C3C /* SymbolChip.swift in Sources */,
-				804ECB802975C68400DE78F4 /* VisibleWhenButtonHoveredViewModifier.swift in Sources */,
-				80301628292C17700016F25E /* AndroidApplication.swift in Sources */,
-				80FDFDB52947D4D9000606AC /* DeviceItem.swift in Sources */,
-				80ED55462971CB3200B3AEBA /* MirrorDeviceDisplayTask.swift in Sources */,
-				80EB5D53296F6A380011DE5F /* Array+JoinedWithSpaces.swift in Sources */,
-				80B536052AB5407700EEB2EF /* SettingsLinkAdditionalActionButtonStyle.swift in Sources */,
-				80564B542983414D002DC136 /* AlertOptions.swift in Sources */,
-				80D71F2A2985C4EE0006E1BF /* ScreenCopyOnboardingItem.swift in Sources */,
-				8090E25A2967741F003106B9 /* TaskProgress.swift in Sources */,
-				80A91A142981BA1300D8A8B9 /* FloatingPanelViewModifier.swift in Sources */,
-				80A66D6C2981BC9900ECBCB6 /* PrepareDeviceAction.swift in Sources */,
-				80629BF22939818C0077960E /* QuickLaunchEntryRow.swift in Sources */,
-				8090E265296774D2003106B9 /* StatusPopover.swift in Sources */,
-				8029B6A52AC239E000BD1D30 /* DeviceIsLockedView.swift in Sources */,
-				80B7BAEA29773EA600267C3C /* ScreenCopyPicker.swift in Sources */,
-				80B7BAD729762D8900267C3C /* NSApplication+ShowSettingsWindow.swift in Sources */,
-				8006E7E12943C9190089805E /* Theme.swift in Sources */,
-				80B48E132C8BD1D500897317 /* ArtifactRetrievalCoordinator.swift in Sources */,
-				8030162C292C1B490016F25E /* ApplicationError.swift in Sources */,
-				80A91A122981BA1300D8A8B9 /* CustomWindowPresentation.swift in Sources */,
-				80462F912CEFA7F2002F6E8F /* ParameterTextField.swift in Sources */,
-				8006E7E72943C9AA0089805E /* ToggleableRowIcon.swift in Sources */,
-				8006E7ED2943CA250089805E /* Panel.swift in Sources */,
-				80564B5629834203002DC136 /* FileTypes.swift in Sources */,
-				80EB5D4B296F64D70011DE5F /* DeviceError+LocalizedError.swift in Sources */,
-				80564B5229834137002DC136 /* TaskStatusReporterDelegate.swift in Sources */,
-				8090E25D2967741F003106B9 /* TaskStatus.swift in Sources */,
-				80691D282CDA9AE9006572CD /* ArtifactDownloader.swift in Sources */,
-				80629BF42939818C0077960E /* QuickLaunchEntrySheet.swift in Sources */,
-				804ECB7C2975C15300DE78F4 /* DevicePicker.swift in Sources */,
-				805FC43229E9BE0A00A78208 /* ArtifactDownloaderError+LocalizedError.swift in Sources */,
-				80462F992CEFF04F002F6E8F /* AppExtensionIdentity+WithXPCSession.swift in Sources */,
-				80629C22293A8D270077960E /* ProvisioningProfile.swift in Sources */,
-				80D71F1C2984CE720006E1BF /* XcodeOnboardingItem.swift in Sources */,
-				802671452947C297001A804D /* MenuHeader.swift in Sources */,
-				80A91A132981BA1300D8A8B9 /* FloatingPanel.swift in Sources */,
-				80D71F2C2985C69B0006E1BF /* OnboardingPopoverContent.swift in Sources */,
-				80B7BAD529762CBB00267C3C /* QuickLaunchEmptyState.swift in Sources */,
-				80CBACF6298991CE00F778DD /* AboutWindowViewModifier.swift in Sources */,
-				80A66D6E2981BC9900ECBCB6 /* MirrorDeviceDisplayAction.swift in Sources */,
-				80B7BAE629773C3D00267C3C /* LocationDetectModePicker.swift in Sources */,
-				80D71F222984CEBD0006E1BF /* CommandLineHelperOnboardingItem.swift in Sources */,
-				80629BF32939818C0077960E /* List+GradientButtons.swift in Sources */,
-				8006E7E52943C9970089805E /* SectionHeadingTextStyle.swift in Sources */,
-				80B7BAE829773E5100267C3C /* AndroidSDKPicker.swift in Sources */,
-				809C8575297B0FA9004CE6A2 /* ShowingAdvancedOptionsViewModifier.swift in Sources */,
-				80301620292874B70016F25E /* ArtifactUnpacker.swift in Sources */,
-				80EB5D4F296F658E0011DE5F /* InstallationTicketMachineError+LocalizedError.swift in Sources */,
-				8079E3562C850FE0000CB5B3 /* View+ShowDockIconWhenOpen.swift in Sources */,
-				80A66D6D2981BC9900ECBCB6 /* ErrorNotifier.swift in Sources */,
-				80FF03EF29087473008509E0 /* InstallCoordinator.swift in Sources */,
-				B6AA44DD296F78670017321C /* GeneralTab.swift in Sources */,
-				80AE75E42CF4F467000923E3 /* QuickLaunchEntryRecipe.swift in Sources */,
-				8029A081298AF1E90002C579 /* ApplicationIcon.swift in Sources */,
-				80EB5D4D296F64F50011DE5F /* ApplicationError+LocalizedError.swift in Sources */,
-				80629BF62939818C0077960E /* GradientButton.swift in Sources */,
-				80F380432984226800A9350F /* NotificationHandler.swift in Sources */,
-				80D71F1E2984CE850006E1BF /* AndroidStudioOnboardingItem.swift in Sources */,
-				80462F8F2CEFA780002F6E8F /* InfoButton.swift in Sources */,
-				80301626292C17560016F25E /* AppleApplication.swift in Sources */,
-				802671492947C72C001A804D /* QuickLaunchEntryView.swift in Sources */,
-				8090E25C2967741F003106B9 /* TaskStatusReporter.swift in Sources */,
-				804FF6592914239800147652 /* Collection+Filter.swift in Sources */,
-				802671472947C33C001A804D /* Bundle+Extensions.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1216,8 +527,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8058B48C2CA630620075D38D /* URLReaderTests.swift in Sources */,
-				7F35026924A5060700EE76EA /* TophatTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1225,14 +534,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				80518F5329846E4300FB8803 /* NSRunningApplication+IsTophatRunning.swift in Sources */,
-				80ED3E5E29835AAF00A734B7 /* URL+ExpressibleByArgument.swift in Sources */,
-				80518F512984681200FB8803 /* Apps+Remove.swift in Sources */,
-				80F3804929843A9F00A9350F /* Install.swift in Sources */,
-				807D7B132983576C007942B4 /* TophatCtl.swift in Sources */,
-				8025A5B429845EB5007B1BA0 /* Apps.swift in Sources */,
-				80518F4F2984600900FB8803 /* Apps+Add.swift in Sources */,
-				80F3804829843A9200A9350F /* Platform+ExpressibleByArgument.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1400,7 +701,6 @@
 		7F35027924A5060700EE76EA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = Tophat/Tophat.entitlements;
@@ -1429,7 +729,6 @@
 		7F35027A24A5060700EE76EA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CODE_SIGN_ENTITLEMENTS = Tophat/Tophat.entitlements;
@@ -1461,7 +760,6 @@
 		7F35027C24A5060700EE76EA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
@@ -1484,7 +782,6 @@
 		7F35027D24A5060700EE76EA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;

--- a/Tophat.xcodeproj/xcshareddata/xcschemes/Tophat.xcscheme
+++ b/Tophat.xcodeproj/xcshareddata/xcschemes/Tophat.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Tophat.xcodeproj/xcshareddata/xcschemes/TophatTests.xcscheme
+++ b/Tophat.xcodeproj/xcshareddata/xcschemes/TophatTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1540"
+   LastUpgradeVersion = "1610"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### What does this change accomplish?

This change upgrades the Xcode project configuration to use the new filesystem synchronized folders feature instead of legacy groups.

### How have you achieved it?

By using "Convert to Folder" in the Xcode sidebar.

### How can the change be tested?

N/A
