### PR TITLE
Add and update `tophatctl` commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Downloads with Tophat are powered by _artifact providers_. Some artifact provide
 
 The format by which this information is specified varies slightly depending on whether you use URLs, Quick Launch, or `tophatctl`, but each API requires roughly the same information.
 
-You can view a list of all artifact provider IDs using `tophatctl providers`.
+You can view a list of all artifact provider IDs using `tophatctl list providers`.
 
 Each request can install multiple artifacts. Within each request, these are called _recipes_, and are particularly useful when you want to have one link that supports both simulators and devices in the same link, where different builds are required for each.
 

--- a/Tophat/TophatApp.swift
+++ b/Tophat/TophatApp.swift
@@ -336,6 +336,18 @@ extension AppDelegate: RemoteControlReceiverDelegate {
 	func remoteControlReceiver(didReceiveRequestToLaunchApplicationWithRecipes recipes: [InstallRecipe]) async {
 		await launchApp(recipes: recipes)
 	}
+
+	func remoteControlReceiver(didReceiveRequestToLaunchQuickLaunchEntryWithIdentifier quickLaunchEntryIdentifier: QuickLaunchEntry.ID) async {
+		let context = ModelContext(modelContainer)
+
+		let fetchDescriptor = FetchDescriptor<QuickLaunchEntry>(
+			predicate: #Predicate { $0.id == quickLaunchEntryIdentifier }
+		)
+
+		if let entry = try? context.fetch(fetchDescriptor).first {
+			await launchApp(quickLaunchEntry: entry)
+		}
+	}
 }
 
 // MARK: - TaskStatusReporterDelegate

--- a/Tophat/TophatApp.swift
+++ b/Tophat/TophatApp.swift
@@ -103,7 +103,10 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
 	private var cancellables = Set<AnyCancellable>()
 
 	override init() {
-		self.remoteControlReceiver = RemoteControlReceiver(extensionHost: extensionHost)
+		self.remoteControlReceiver = RemoteControlReceiver(
+			extensionHost: extensionHost,
+			modelContainer: modelContainer
+		)
 
 		self.deviceManager = DeviceManager(sources: [
 			AppleDevices.self,

--- a/Tophat/TophatApp.swift
+++ b/Tophat/TophatApp.swift
@@ -80,7 +80,7 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
 	let extensionHost = ExtensionHost()
 	private let server = TophatServer()
 	private let urlHandler = URLReader()
-	private let remoteControlReceiver = RemoteControlReceiver()
+	private let remoteControlReceiver: RemoteControlReceiver
 
 	let deviceManager: DeviceManager
 	let utilityPathPreferences: UtilityPathPreferences
@@ -103,6 +103,8 @@ private final class AppDelegate: NSObject, NSApplicationDelegate {
 	private var cancellables = Set<AnyCancellable>()
 
 	override init() {
+		self.remoteControlReceiver = RemoteControlReceiver(extensionHost: extensionHost)
+
 		self.deviceManager = DeviceManager(sources: [
 			AppleDevices.self,
 			AndroidDevices.self

--- a/Tophat/Utilities/RemoteControlReceiver.swift
+++ b/Tophat/Utilities/RemoteControlReceiver.swift
@@ -16,6 +16,7 @@ protocol RemoteControlReceiverDelegate: AnyObject, Sendable {
 	func remoteControlReceiver(didReceiveRequestToAddQuickLaunchEntry quickLaunchEntry: QuickLaunchEntry)
 	func remoteControlReceiver(didReceiveRequestToRemoveQuickLaunchEntryWithIdentifier quickLaunchEntryIdentifier: QuickLaunchEntry.ID)
 	func remoteControlReceiver(didReceiveRequestToLaunchApplicationWithRecipes recipes: [InstallRecipe]) async
+	func remoteControlReceiver(didReceiveRequestToLaunchQuickLaunchEntryWithIdentifier quickLaunchEntryIdentifier: QuickLaunchEntry.ID) async
 	func remoteControlReceiver(didOpenURL url: URL, launchArguments: [String]) async
 }
 
@@ -142,6 +143,13 @@ struct RemoteControlReceiver {
 						}
 					)
 				)
+			}
+		}
+
+		Task {
+			for await request in service.requests(for: InstallFromQuickLaunchRequest.self) {
+				await delegate.remoteControlReceiver(didReceiveRequestToLaunchQuickLaunchEntryWithIdentifier: request.value.quickLaunchEntryID)
+				request.reply(.init())
 			}
 		}
 	}

--- a/TophatCtl/Commands/Apps/Apps+Add.swift
+++ b/TophatCtl/Commands/Apps/Apps+Add.swift
@@ -12,11 +12,31 @@ import TophatFoundation
 import TophatControlServices
 import AppKit
 
+private let discussion = """
+If an existing item with the same identifier already exists, the item will be updated with new information.
+
+Use the following JSON format when specifying a configuration file:
+
+{
+  "id": "example",
+  "name": "Example",
+  "recipes": [
+    {
+      "artifactProviderID": "example",
+      "artifactProviderParameters": {},
+      "launchArguments": [],
+      "platformHint": "ios",
+      "destinationHint": "simulator"
+    }
+  ]
+}
+"""
+
 extension Apps {
 	struct Add: AsyncParsableCommand {
 		static let configuration = CommandConfiguration(
 			abstract: "Adds a new application to Quick Launch.",
-			discussion: "If an existing item with the same identifier already exists, the item will be updated with new information."
+			discussion: discussion
 		)
 
 		@Argument(help: "The path to the configuration file for the app.")

--- a/TophatCtl/Commands/Apps/Apps+Add.swift
+++ b/TophatCtl/Commands/Apps/Apps+Add.swift
@@ -23,9 +23,7 @@ extension Apps {
 		var path: URL
 
 		func run() async throws {
-			if !NSRunningApplication.isTophatRunning {
-				print("Warning: Tophat must be running for this command to succeed, but it is not running.")
-			}
+			checkIfHostAppIsRunning()
 
 			let data = try Data(contentsOf: path)
 			let configuration = try JSONDecoder().decode(UserSpecifiedQuickLaunchEntryConfiguration.self, from: data)

--- a/TophatCtl/Commands/Apps/Apps+Remove.swift
+++ b/TophatCtl/Commands/Apps/Apps+Remove.swift
@@ -22,9 +22,7 @@ extension Apps {
 		var id: String
 
 		func run() throws {
-			if !NSRunningApplication.isTophatRunning {
-				print("Warning: Tophat must be running for this command to succeed, but it is not running.")
-			}
+			checkIfHostAppIsRunning()
 
 			let request = RemoveQuickLaunchEntryRequest(quickLaunchEntryID: id)
 			try TophatRemoteControlService().send(request: request)

--- a/TophatCtl/Commands/Install.swift
+++ b/TophatCtl/Commands/Install.swift
@@ -38,6 +38,8 @@ struct Install: AsyncParsableCommand {
 	var launchArguments: [String] = []
 
 	func run() async throws {
+		checkIfHostAppIsRunning()
+
 		let service = TophatRemoteControlService()
 		let urlParsedAsArgument = URL(argument: idOrPath)
 

--- a/TophatCtl/Commands/List.swift
+++ b/TophatCtl/Commands/List.swift
@@ -12,6 +12,7 @@ struct List: AsyncParsableCommand {
 	static let configuration = CommandConfiguration(
 		abstract: "Lists things Tophat knows about.",
 		subcommands: [
+			Apps.self,
 			Providers.self
 		]
 	)

--- a/TophatCtl/Commands/List.swift
+++ b/TophatCtl/Commands/List.swift
@@ -1,0 +1,18 @@
+//
+//  List.swift
+//  tophatctl
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import ArgumentParser
+
+struct List: AsyncParsableCommand {
+	static let configuration = CommandConfiguration(
+		abstract: "Lists things Tophat knows about.",
+		subcommands: [
+			Providers.self
+		]
+	)
+}

--- a/TophatCtl/Commands/List/List+Apps.swift
+++ b/TophatCtl/Commands/List/List+Apps.swift
@@ -16,6 +16,8 @@ extension List {
 		)
 
 		func run() async throws {
+			checkIfHostAppIsRunning()
+
 			let reply = try await TophatRemoteControlService().send(request: ListAppsRequset())
 
 			print("Apps:")

--- a/TophatCtl/Commands/List/List+Apps.swift
+++ b/TophatCtl/Commands/List/List+Apps.swift
@@ -1,0 +1,34 @@
+//
+//  List+Apps.swift
+//  tophatctl
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import ArgumentParser
+import TophatControlServices
+
+extension List {
+	struct Apps: AsyncParsableCommand {
+		static let configuration = CommandConfiguration(
+			abstract: "Lists all apps configured for Quick Launch in Tophat."
+		)
+
+		func run() async throws {
+			let reply = try await TophatRemoteControlService().send(request: ListAppsRequset())
+
+			print("Apps:")
+
+			for app in reply.apps {
+				print()
+
+				print("‣\u{001B}[1m", app.name, "\u{001B}[22m")
+				print("  Identifier:", app.id)
+				print("  Platforms:", app.platforms.map { String(describing: $0) }.joined(separator: ", "))
+				print("  Recipes:", app.recipeCount)
+
+			}
+		}
+	}
+}

--- a/TophatCtl/Commands/List/List+Providers.swift
+++ b/TophatCtl/Commands/List/List+Providers.swift
@@ -16,6 +16,8 @@ extension List {
 		)
 
 		func run() async throws {
+			checkIfHostAppIsRunning()
+
 			let reply = try await TophatRemoteControlService().send(request: ListProvidersRequest())
 
 			print("Providers:")

--- a/TophatCtl/Commands/List/List+Providers.swift
+++ b/TophatCtl/Commands/List/List+Providers.swift
@@ -1,0 +1,38 @@
+//
+//  List+Providers.swift
+//  tophatctl
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import ArgumentParser
+import TophatControlServices
+
+extension List {
+	struct Providers: AsyncParsableCommand {
+		static let configuration = CommandConfiguration(
+			abstract: "Lists all providers available in Tophat."
+		)
+
+		func run() async throws {
+			let reply = try await TophatRemoteControlService().send(request: ListProvidersRequest())
+
+			print("Providers:")
+
+			for provider in reply.providers {
+				print()
+
+				print("‣\u{001B}[1m", provider.title, "\u{001B}[22m")
+				print("  Identifier:", provider.id)
+				print("  Extension:", provider.extensionTitle)
+				print("  Parameters:")
+
+				for parameter in provider.parameters {
+					print("    ‣ Key:", parameter.key)
+					print("      Title:", parameter.title)
+				}
+			}
+		}
+	}
+}

--- a/TophatCtl/Extensions/AsyncParsableCommand+Extensions.swift
+++ b/TophatCtl/Extensions/AsyncParsableCommand+Extensions.swift
@@ -1,0 +1,18 @@
+//
+//  AsyncParsableCommand+Extensions.swift
+//  tophatctl
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import AppKit
+import ArgumentParser
+
+extension AsyncParsableCommand {
+	func checkIfHostAppIsRunning() {
+		if !NSRunningApplication.isTophatRunning {
+			print("Warning: Tophat must be running for this command to succeed, but it is not running.")
+		}
+	}
+}

--- a/TophatCtl/TophatCtl.swift
+++ b/TophatCtl/TophatCtl.swift
@@ -15,7 +15,8 @@ struct TophatCtl: AsyncParsableCommand {
 		abstract: "A utility for interacting with Tophat from command line applications.",
 		subcommands: [
 			Install.self,
-			Apps.self
+			Apps.self,
+			List.self
 		]
 	)
 }

--- a/TophatModules/Sources/TophatControlServices/Requests/InstallFromQuickLaunchRequest.swift
+++ b/TophatModules/Sources/TophatControlServices/Requests/InstallFromQuickLaunchRequest.swift
@@ -1,0 +1,21 @@
+//
+//  InstallFromQuickLaunchRequest.swift
+//  TophatControlServices
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import Foundation
+
+public struct InstallFromQuickLaunchRequest: TophatRemoteControlRequest {
+	public typealias Reply = InstallationRequestReply
+
+	public let id: UUID
+	public let quickLaunchEntryID: String
+
+	public init(quickLaunchEntryID: String) {
+		self.id = UUID()
+		self.quickLaunchEntryID = quickLaunchEntryID
+	}
+}

--- a/TophatModules/Sources/TophatControlServices/Requests/ListAppsRequest.swift
+++ b/TophatModules/Sources/TophatControlServices/Requests/ListAppsRequest.swift
@@ -1,0 +1,40 @@
+//
+//  ListAppsRequset.swift
+//  TophatControlServices
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import Foundation
+import TophatFoundation
+
+public struct ListAppsRequset: TophatRemoteControlRequest {
+	public struct Reply: Codable, Sendable {
+		public struct App: Codable, Sendable {
+			public let id: String
+			public let name: String
+			public let platforms: Set<Platform>
+			public let recipeCount: Int
+
+			public init(id: String, name: String, platforms: Set<Platform>, recipeCount: Int) {
+				self.id = id
+				self.name = name
+				self.platforms = platforms
+				self.recipeCount = recipeCount
+			}
+		}
+
+		public let apps: [App]
+
+		public init(apps: [App]) {
+			self.apps = apps
+		}
+	}
+
+	public let id: UUID
+
+	public init() {
+		self.id = UUID()
+	}
+}

--- a/TophatModules/Sources/TophatControlServices/Requests/ListProvidersRequest.swift
+++ b/TophatModules/Sources/TophatControlServices/Requests/ListProvidersRequest.swift
@@ -1,0 +1,49 @@
+//
+//  ListProvidersRequest.swift
+//  TophatControlServices
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import Foundation
+
+public struct ListProvidersRequest: TophatRemoteControlRequest {
+	public struct Reply: Codable, Sendable {
+		public struct Provider: Codable, Sendable {
+			public struct Parameter: Codable, Sendable {
+				public let key: String
+				public let title: String
+
+				public init(key: String, title: String) {
+					self.key = key
+					self.title = title
+				}
+			}
+
+			public let id: String
+			public let title: String
+			public let extensionTitle: String
+			public let parameters: [Parameter]
+
+			public init(id: String, title: String, extensionTitle: String, parameters: [Parameter]) {
+				self.id = id
+				self.title = title
+				self.extensionTitle = extensionTitle
+				self.parameters = parameters
+			}
+		}
+
+		public let providers: [Provider]
+
+		public init(providers: [Provider]) {
+			self.providers = providers
+		}
+	}
+
+	public let id: UUID
+
+	public init() {
+		self.id = UUID()
+	}
+}


### PR DESCRIPTION
### What does this change accomplish?

This change accomplishes the following:
- Updates the existing `tophatctl install` command to accept a Quick Launch entry identifier, path or URL to an artifact, or path to a JSON configuration file. This allows users to launch Quick Launch entries using only their identifiers.
- Adds a new `tophatctl list apps` command that displays a list of Quick Launch entries and their identifiers.
- Adds a new `tophatctl list providers` command that displays a list of artifact providers and their metadata including identifiers and parameter keys.
- Improves command documentation to include example JSON formats.

### How have you achieved it?

By adding new `TophatRemoteControlRequest` entities for each request, adding handlers for them to `RemoteControlReceiver`, and implementing the corresponding commands in `tophatctl`.

### How can the change be tested?

Run each of the commands described above and ensure that they are working as expected.