### PR TITLE
Replace missing host trust prompt for HTTP downloads

### DIFF
--- a/Tophat/Extensions/ArtifactDownloaderError+LocalizedError.swift
+++ b/Tophat/Extensions/ArtifactDownloaderError+LocalizedError.swift
@@ -12,21 +12,27 @@ extension ArtifactDownloaderError: LocalizedError {
 	var errorDescription: String? {
 		switch self {
 			case .failedToDownloadArtifact:
-				return "The artifact could not be downloaded"
+				"The artifact could not be downloaded"
+			case .untrustedHost:
+				"The download was aborted"
 		}
 	}
 
 	var failureReason: String? {
 		switch self {
 			case .failedToDownloadArtifact:
-				return "An unexpected error occurred while downloading the artifact."
+				"An unexpected error occurred while downloading the artifact."
+			case .untrustedHost:
+				"The host that the artifact is being downloaded from is untrusted."
 		}
 	}
 
 	var recoverySuggestion: String? {
 		switch self {
 			case .failedToDownloadArtifact:
-				return "Check your network connection and try again."
+				"Check your network connection and try again."
+			case .untrustedHost:
+				"Verify that you trust the origin of the artifact before retrying."
 		}
 	}
 }


### PR DESCRIPTION
### What does this change accomplish?

This change replaces the missing host trust prompt when using the built-in HTTP artifact provider.

### How have you achieved it?

By adding a check to `ArtifactDownloader` that prompts the user using the existing `TrustedHostAlert` if the artifact provider ID is `http`.

### How can the change be tested?

Download an artifact using the `http` build provider (either through a URL, `tophatctl`, or Quick Launch) and ensure that you are prompted to trust the host the first time.