### PR TITLE
Add menu items to deselect devices and to empty caches

### DIFF
--- a/Tophat/Views/DeselectAllDevicesMenuItem.swift
+++ b/Tophat/Views/DeselectAllDevicesMenuItem.swift
@@ -1,0 +1,30 @@
+//
+//  DeselectAllDevicesMenuItem.swift
+//  Tophat
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import SwiftUI
+
+struct DeselectAllDevicesMenuItem: View {
+	@EnvironmentObject private var deviceSelectionManager: DeviceSelectionManager
+
+	var body: some View {
+		Button {
+			deviceSelectionManager.selectedDevices.removeAll()
+		} label: {
+			HStack {
+				Text("Deselect All")
+				Spacer()
+				if !deviceSelectionManager.selectedDevices.isEmpty {
+					Text("\(deviceSelectionManager.selectedDevices.count) Selected")
+						.foregroundStyle(.tertiary)
+						.monospacedDigit()
+				}
+			}
+		}
+		.buttonStyle(.menuItem(blinks: true, disabled: deviceSelectionManager.selectedDevices.isEmpty))
+	}
+}

--- a/Tophat/Views/EmptyCachesMenuItem.swift
+++ b/Tophat/Views/EmptyCachesMenuItem.swift
@@ -1,0 +1,45 @@
+//
+//  EmptyCachesMenuItem.swift
+//  Tophat
+//
+//  Created by Lukas Romsicki on 2024-12-04.
+//  Copyright © 2024 Shopify. All rights reserved.
+//
+
+import SwiftUI
+import TophatFoundation
+
+struct EmptyCachesMenuItem: View {
+	private let cacheURL: URL = .cachesDirectory.appending(path: Bundle.main.bundleIdentifier!)
+
+	@EnvironmentObject private var taskStatusReporter: TaskStatusReporter
+	@State private var bytes: Int64 = 0
+
+	var body: some View {
+		Button {
+			Task {
+				try? FileManager.default.removeItem(at: cacheURL)
+				await calculateSize()
+			}
+		} label: {
+			HStack {
+				Text("Empty Caches")
+				Spacer()
+				Text("Size: \(bytes, format: .byteCount(style: .file, spellsOutZero: true))")
+					.foregroundStyle(.tertiary)
+			}
+		}
+		.buttonStyle(.menuItem(blinks: true, disabled: !taskStatusReporter.statuses.isEmpty || bytes == 0))
+		.task {
+			await calculateSize()
+		}
+	}
+
+	private func calculateSize() async {
+		do {
+			bytes = try await cacheURL.calculateSizeInBytes()
+		} catch {
+			log.error("Failed to calculate the size of the cache directory: \(error)")
+		}
+	}
+}

--- a/Tophat/Views/MainMenu.swift
+++ b/Tophat/Views/MainMenu.swift
@@ -35,7 +35,10 @@ struct MainMenu: View {
 			Divider()
 				.padding(.horizontal, Theme.Size.menuPaddingHorizontal)
 
-			LaunchFromLocationMenuItem()
+			VStack(alignment: .leading, spacing: 0) {
+				DeselectAllDevicesMenuItem()
+				LaunchFromLocationMenuItem()
+			}
 
 			if showingAdvancedOptions {
 				Divider()

--- a/Tophat/Views/MainMenu.swift
+++ b/Tophat/Views/MainMenu.swift
@@ -59,6 +59,11 @@ struct MainMenu: View {
 					}
 					.buttonStyle(.menuItem(activatesApplication: true, blinks: true))
 				}
+
+				Divider()
+					.padding(.horizontal, Theme.Size.menuPaddingHorizontal)
+
+				EmptyCachesMenuItem()
 			}
 
 			Divider()

--- a/TophatModules/Sources/TophatFoundation/URL+Extensions.swift
+++ b/TophatModules/Sources/TophatFoundation/URL+Extensions.swift
@@ -20,4 +20,28 @@ public extension URL {
 
 		return result
 	}
+
+	nonisolated func calculateSizeInBytes() async throws -> Int64 {
+		guard let enumerator = FileManager.default.enumerator(
+			at: self,
+			includingPropertiesForKeys: [.isDirectoryKey],
+			options: [.skipsHiddenFiles]
+		) else {
+			return 0
+		}
+
+		let files = enumerator.compactMap { $0 as? URL }
+
+		let nonDirectoryFiles = files.filter { url in
+			(try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == false
+		}
+
+		return try nonDirectoryFiles.reduce(0) { total, url in
+			guard let fileSize = try url.resourceValues(forKeys: [.fileSizeKey]).fileSize else {
+				return total
+			}
+
+			return total + Int64(fileSize)
+		}
+	}
 }


### PR DESCRIPTION
### What does this change accomplish?

This change adds two new menu items: one to deselect all currently selected devices (helps to get back to a clean state now that multiple can be selected) and one to empty caches and display their size.

<img width="435" alt="Screenshot 2024-12-04 at 7 46 29 PM" src="https://github.com/user-attachments/assets/c699c8e1-215f-46f2-81c6-d84c904f8dfa">

### How have you achieved it?

By adding two new SwiftUI views for each item, and by writing a quick URL helper that recursively calculates directory size.  The Tophat cache is pretty flat so this shouldn't be too expensive.  Usually, the size of the directory will be pretty small as Tophat already should be automatically cleaning up artifacts.

### How can the change be tested?

1. Open the Tophat menu and select some devices.
2. Click "Deselect All" and observe that all devices are deselected.
3. <kbd>option</kbd> + click the Tophat menu and observe that you see a new "Empty Caches" item.
4. Install an app.  Within 30 seconds of completing install, you should be able to empty the cache before it automatically gets cleaned up back to 0.
