### PR TITLE
Fix saving of Quick Launch entries

### DIFF
--- a/Tophat/TophatApp.swift
+++ b/Tophat/TophatApp.swift
@@ -309,8 +309,10 @@ extension AppDelegate: RemoteControlReceiverDelegate {
 				quickLaunchEntry.order = lastOrder + 1
 
 				context.insert(quickLaunchEntry)
-				try context.save()
 			}
+
+			try context.save()
+
 		} catch {
 			log.error("Failed to update Quick Launch entry!")
 		}

--- a/TophatExtensions/TophatBitriseExtension/Localizable.xcstrings
+++ b/TophatExtensions/TophatBitriseExtension/Localizable.xcstrings
@@ -34,7 +34,7 @@
     "Token" : {
 
     },
-    "Workflow Name" : {
+    "Workflow" : {
 
     }
   },


### PR DESCRIPTION
### What does this change accomplish?

This change fixes an issue where Quick Launch entries were not getting updated if they already exist.

### How have you achieved it?

By ensuring that `context.save()` is called after the model is updated.

### How can the change be tested?

1. Add a Quick Launch entry using `tophatctl`.
2. Modify the configuration you used, and add the same app again.
3. Ensure that the change is reflected in the UI.