### PR TITLE
Fix issue that prevents deletion of apps in Quick Launch

### DIFF
--- a/Tophat/Views/Settings/AppsTab.swift
+++ b/Tophat/Views/Settings/AppsTab.swift
@@ -58,6 +58,7 @@ struct AppsTab: View {
 						for index in indexSet {
 							let entry = entries[index]
 							modelContext.delete(entry)
+							try? modelContext.save()
 						}
 					}
 				}
@@ -69,6 +70,7 @@ struct AppsTab: View {
 					GradientButton(style: .minus) {
 						if let selectedEntry {
 							modelContext.delete(selectedEntry)
+							try? modelContext.save()
 							self.selectedEntry = nil
 						}
 					}


### PR DESCRIPTION
### What does this change accomplish?

When deleting an app from Quick Launch in Tophat's settings, the Quick Launch palette would not update with the changes.  This is because we were not explicitly saving the changes to the model context.

A workaround is to rearrange items, which does cause the changes to be saved properly.

### How have you achieved it?

By adding the missing calls to `modelContext.save()` after deleting the records.

### How can the change be tested?

1. Add a dummy app in Tophat → Settings → Apps.
2. Observe that you see it in Quick Launch.
3. Delete the app.
4. Observe that the app is gone from Quick Launch.
