### PR TITLE
Fix encoding for localhost URLs

### DIFF
--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -61,8 +61,10 @@ public final class TophatServer {
 		}
 
 		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
-		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding,
-                        let url = URL(string: decodedString) else {
+		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding else {
+			return .internalServerError
+		}
+		guard let url = URL(string: decodedString) else {
 			return .internalServerError
 		}
 

--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -62,7 +62,7 @@ public final class TophatServer {
 
 		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
 		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding,
-			  let url = URL(string: decodedString) else {
+              let url = URL(string: decodedString) else {
 			return .internalServerError
 		}
 

--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -62,7 +62,7 @@ public final class TophatServer {
 
 		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
 		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding,
-                    let url = URL(string: decodedString) else {
+                        let url = URL(string: decodedString) else {
 			return .internalServerError
 		}
 

--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -62,7 +62,7 @@ public final class TophatServer {
 
 		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
 		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding,
-                let url = URL(string: decodedString) else {
+                    let url = URL(string: decodedString) else {
 			return .internalServerError
 		}
 

--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -56,7 +56,13 @@ public final class TophatServer {
 
 		let queryItems = request.queryParams.map { URLQueryItem(name: $0, value: $1) }
 
-		guard let url = baseURL?.appending(path: request.path).appending(queryItems: queryItems) else {
+		guard let baseURL = baseURL else {
+			return .internalServerError
+		}
+
+		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
+		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding,
+			  let url = URL(string: decodedString) else {
 			return .internalServerError
 		}
 

--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -62,7 +62,7 @@ public final class TophatServer {
 
 		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
 		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding,
-              let url = URL(string: decodedString) else {
+                let url = URL(string: decodedString) else {
 			return .internalServerError
 		}
 

--- a/TophatModules/Sources/TophatServer/TophatServer.swift
+++ b/TophatModules/Sources/TophatServer/TophatServer.swift
@@ -54,17 +54,9 @@ public final class TophatServer {
 			return .internalServerError
 		}
 
-		let queryItems = request.queryParams.map { URLQueryItem(name: $0, value: $1) }
+		let queryItems = request.queryParams.map { URLQueryItem(name: $0, value: $1.removingPercentEncoding) }
 
-		guard let baseURL = baseURL else {
-			return .internalServerError
-		}
-
-		let encodedURL = baseURL.appending(path: request.path).appending(queryItems: queryItems)
-		guard let decodedString = encodedURL.absoluteString.removingPercentEncoding else {
-			return .internalServerError
-		}
-		guard let url = URL(string: decodedString) else {
+		guard let url = baseURL?.appending(path: request.path).appending(queryItems: queryItems) else {
 			return .internalServerError
 		}
 


### PR DESCRIPTION
### What does this change accomplish?

When using `tophat://install/url?=<encoded_url>`, things work well, but if we swap it to the `localhost` host (i.e. `http://localhost:29070/install/url?=<encoded_url>`), the code unintentionally encodes the URL, causing an installation failure.

### How have you achieved it?

Decoding the URL when it's passed into the `TophatServer` (used only by `localhost` hosts) solves this issue.

### How can the change be tested?

Try an encoded URL with the `tophat` scheme. It should behave the same way as the `localhost` host
