### PR TITLE
[MOBILE-2302] Patch Fix for HTTP URL Downloads

### DIFF
--- a/Tophat/Info.plist
+++ b/Tophat/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
This PR includes two changes to enable HTTP URL downloads (e.g., from an S3 bucket)–a workaround for downloading HTTP URLs ending in `.zip` in `ArtifactDownloader` and adding `AllowsArbitraryLoads` to `Info.plist` to enable HTTP downloads.
