### PR TITLE
Use `getprop` to resolve AVD name for modern devices

### DIFF
--- a/TophatModules/Sources/AndroidDeviceKit/Extensions/ShellCommand+Adb.swift
+++ b/TophatModules/Sources/AndroidDeviceKit/Extensions/ShellCommand+Adb.swift
@@ -20,6 +20,7 @@ enum AdbCommand {
 	case install(serial: String, apkUrl: URL)
 	case launch(serial: String, componentName: String, arguments: [String])
 	case avdName(serial: String)
+	case getProp(serial: String, property: String)
 	case waitForDevice(serial: String)
 	case resolveActivity(serial: String, packageName: String)
 }
@@ -48,6 +49,9 @@ extension AdbCommand: ShellCommand {
 
 			case .avdName(let serial):
 				return ["-s", serial, "emu", "avd", "name"]
+
+			case .getProp(let serial, let property):
+				return ["-s", serial, "shell", "getprop", property]
 
 			case .waitForDevice(let serial):
 				return ["-s", serial, "wait-for-device", "shell", "'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done;'"]


### PR DESCRIPTION
### What does this change accomplish?

This change addresses an issue where `adb emu avd name` does not work consistently for modern emulators, which causes issues with Tophat and some AVDs.

### How have you achieved it?

By using a combination of the following two commands which work more reliably on different devices:
- `adb shell getprop ro.kernel.qemu.avd_name`
- `adb shell getprop ro.boot.qemu.avd_name`

The first works on newer emulators, and the second works on older emulators.  Tophat will fall back to the second if the first doesn't work, and if neither work, it will fall back to `adb emu avd name`.

### How can the change be tested?

In an environment with AVDs on API levels both greater or equal to 35 and also lower than 35, test that using Tophat to interact with each of those sets of devices works as expected.
