### PR TITLE
Bump minimum deployment to macOS 15

### DIFF
--- a/Configurations/Project.xcconfig
+++ b/Configurations/Project.xcconfig
@@ -6,4 +6,4 @@
 //  Copyright © 2024 Shopify. All rights reserved.
 //
 
-MACOSX_DEPLOYMENT_TARGET = 14.0
+MACOSX_DEPLOYMENT_TARGET = 15.0


### PR DESCRIPTION
### What does this change accomplish?

This change increases the minimum deployment target of Tophat to macOS 15.  This lets us start using some new APIs to move away from some of the hacky workarounds we have today.

### How have you achieved it?

By updating the value in `Project.xcconfig`.

### How can the change be tested?

N/A
