### PR TITLE
Improve flexibility in artifact archive structure

### DIFF
--- a/Tophat/Extensions/URL+IsDirectory.swift
+++ b/Tophat/Extensions/URL+IsDirectory.swift
@@ -1,0 +1,15 @@
+//
+//  URL+IsDirectory.swift
+//  Tophat
+//
+//  Created by Lukas Romsicki on 2025-06-26.
+//  Copyright © 2025 Shopify. All rights reserved.
+//
+
+import Foundation
+
+extension URL {
+	var isDirectory: Bool {
+		(try? resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+	}
+}

--- a/Tophat/Utilities/ArtifactUnpacker.swift
+++ b/Tophat/Utilities/ArtifactUnpacker.swift
@@ -24,7 +24,25 @@ final class ArtifactUnpacker: Sendable {
 
 	private func unpack(artifactURL: URL) throws -> Application {
 		guard let fileFormat = ArtifactFileFormat(pathExtension: artifactURL.pathExtension) else {
-			throw ArtifactUnpackerError.unknownFileFormat
+			guard artifactURL.isDirectory else {
+				throw ArtifactUnpackerError.unknownFileFormat
+			}
+
+			let enclosedFileURLs = try FileManager.default.contentsOfDirectory(
+				at: artifactURL,
+				includingPropertiesForKeys: nil
+			)
+
+			let supportedPathExtensions = ArtifactFileFormat.allCases.map(\.pathExtension)
+			let supportedEnclosedFileURLs = enclosedFileURLs.filter { fileURL in
+				supportedPathExtensions.contains(fileURL.pathExtension)
+			}
+
+			guard let firstSupportedEnclosedFileURL = supportedEnclosedFileURLs.first else {
+				throw ArtifactUnpackerError.unknownFileFormat
+			}
+
+			return try unpack(artifactURL: firstSupportedEnclosedFileURL)
 		}
 
 		switch fileFormat {
@@ -60,7 +78,13 @@ final class ArtifactUnpacker: Sendable {
 	}
 
 	private func extractArtifact(at url: URL) throws -> URL {
-		let destinationURL = url.deletingLastPathComponent().appending(path: url.fileName)
+		let archive = try Archive(url: url, accessMode: .read)
+
+		// Since application bundles are directories, avoid creating invalid
+		// bundles if the destination directory would happen to end in ".app"
+		let isDirectlyArchivedApplicationBundle = archive["Info.plist"] != nil
+		let destinationFileName = isDirectlyArchivedApplicationBundle ? url.fileName : url.fileRoot
+		let destinationURL = url.deletingLastPathComponent().appending(path: destinationFileName)
 
 		log.info("Uncompressing artifact at \(url)")
 		try FileManager.default.unzipItem(at: url, to: destinationURL)
@@ -73,6 +97,10 @@ final class ArtifactUnpacker: Sendable {
 private extension URL {
 	var fileName: String {
 		lastPathComponent.replacingOccurrences(of: ".\(pathExtension)", with: "")
+	}
+
+	var fileRoot: String {
+		lastPathComponent.components(separatedBy: ".").first ?? lastPathComponent
 	}
 }
 


### PR DESCRIPTION
### What does this change accomplish?

This change updates how artifacts are unpacked to support a wider variety of structures, including:
- Any type of application artifact (`.app`, `.ipa`, `.apk`) in a zip file.
- Any type of application artifact in a zip file containing a parent directory (created if compressed directly in Finder, for example).

Resolves #32

### How have you achieved it?

By updating the logic to fall back to an alternate code path if the URL does not end in a supported extension.  In particular, URLs with **no** path extension are handled here, with all other cases throwing an error.  When in the directory, Tophat will pick the first file with a supported extension if one exists and recurse to unpack it further.

A separate case is added to `extractArtifact(artifactURL:)` to ensure that `.app` bundles whose contents are zipped (rather than the parent directory itself) are also handled correctly without adding unnecessary/invalid path extensions.

### How can the change be tested?

- Ensure that existing download/install workflows continue to work without changes.
- Ensure that providing Tophat with artifacts zipped with parent directories, or zipped `.ipa` or `.apk` also work.