### PR TITLE
Include only devices with physical reality in `devicectl` list

### DIFF
--- a/Tophat/Utilities/LaunchAppAction.swift
+++ b/Tophat/Utilities/LaunchAppAction.swift
@@ -16,7 +16,7 @@ struct LaunchAppAction {
 		self.installCoordinator = installCoordinator
 	}
 
-	func callAsFunction(quickLaunchEntry entry: QuickLaunchEntry) async {
+	@MainActor func callAsFunction(quickLaunchEntry entry: QuickLaunchEntry) async {
 		let context = OperationContext(quickLaunchEntryID: entry.id, applicationDisplayName: entry.name)
 		await callAsFunction(recipes: entry.installRecipes, context: context)
 	}

--- a/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+DeviceCtl.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+DeviceCtl.swift
@@ -34,7 +34,7 @@ extension DeviceCtlCommand: ShellCommand {
 					"devicectl",
 					"list",
 					"devices",
-					"--filter", "hardwareProperties.platform MATCHES 'iOS'",
+					"--filter", "hardwareProperties.platform MATCHES 'iOS' AND hardwareProperties.reality MATCHES 'physical'",
 					"--json-output", .safe(outputUrl.formattedAsArgument())
 				]
 


### PR DESCRIPTION
### What does this change accomplish?

In Xcode 27, `devicectl` also supports devices with simulated reality, but Tophat does not yet correctly handle this case resulting in all simulators appearing in the uncollapsed devices list.

Resolves #146

### How have you achieved it?

In a future version, Tophat will be updated to no longer reference deprecated `devicectl` fields and fully leverage new APIs, but in the meantime, the `devicectl list devices` query is being filtered directly using the `--filter` option directly in the call to the CLI tool itself.

### How can the change be tested?

With Xcode 27 installed and ready, open Tophat and ensure that you don't see any extraneous simulators in the top list.