### PR TITLE
Add support for Device Hub in Xcode 27

### DIFF
--- a/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+Open.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+Open.swift
@@ -16,7 +16,8 @@ extension ShellCommand where Self == OpenCommand {
 }
 
 enum OpenCommand {
-	case simulator
+	case application(url: URL, arguments: [String] = [])
+	case applicationName(_ name: String)
 }
 
 extension OpenCommand: ShellCommand {
@@ -26,8 +27,16 @@ extension OpenCommand: ShellCommand {
 
 	var arguments: [ShellArgument] {
 		switch self {
-			case .simulator:
-				return ["-a", "Simulator.app"]
+			case .application(let url, let arguments):
+				var shellArguments: [ShellArgument] = ["-a", .safe(url.path(percentEncoded: false))]
+
+				if !arguments.isEmpty {
+					shellArguments.append(contentsOf: arguments.map { .safe($0) })
+				}
+
+				return shellArguments
+			case .applicationName(let name):
+				return ["-a", .safe(name)]
 		}
 	}
 }

--- a/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+XcodeSelect.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Extensions/ShellCommand+XcodeSelect.swift
@@ -1,0 +1,33 @@
+//
+//  ShellCommand+XcodeSelect.swift
+//  AppleDeviceKit
+//
+//  Created by Lukas Romsicki on 2026-07-31.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+import ShellKit
+
+extension ShellCommand where Self == XcodeSelectCommand {
+	static func xcodeSelect(_ command: Self) -> Self {
+		command
+	}
+}
+
+enum XcodeSelectCommand {
+	case printPath
+}
+
+extension XcodeSelectCommand: ShellCommand {
+	var executable: Executable {
+		.url(URL(filePath: "/usr/bin/xcode-select"))
+	}
+
+	var arguments: [ShellArgument] {
+		switch self {
+			case .printPath:
+				["--print-path"]
+		}
+	}
+}

--- a/TophatModules/Sources/AppleDeviceKit/Simulator+Device.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Simulator+Device.swift
@@ -48,7 +48,16 @@ extension Simulator: Device {
 
 	func focus() throws {
 		do {
-			try run(command: .open(.simulator), log: log)
+			if let deviceHubURL = XcodeHelper.deviceHubURL() {
+				let appLinkString = "devices://manage/select?id=\(id)"
+
+				try run(
+					command: .open(.application(url: deviceHubURL, arguments: [appLinkString])),
+					log: log
+				)
+			} else {
+				try run(command: .open(.applicationName("Simulator.app")), log: log)
+			}
 		} catch {
 			throw DeviceError.failedToFocus
 		}

--- a/TophatModules/Sources/AppleDeviceKit/Utilities/XcodeHelper.swift
+++ b/TophatModules/Sources/AppleDeviceKit/Utilities/XcodeHelper.swift
@@ -1,0 +1,35 @@
+//
+//  XcodeHelper.swift
+//  AppleDeviceKit
+//
+//  Created by Lukas Romsicki on 2026-07-31.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+import ShellKit
+
+struct XcodeHelper {
+	static func deviceHubURL() -> URL? {
+		guard let selectedDeveloperDirectoryPath = try? run(command: .xcodeSelect(.printPath), log: log) else {
+			return nil
+		}
+
+		let trimmedDeveloperDirectoryPath = selectedDeveloperDirectoryPath.trimmingCharacters(in: .whitespacesAndNewlines)
+
+		guard !trimmedDeveloperDirectoryPath.isEmpty else {
+			return nil
+		}
+
+		let deviceHubURL = URL(filePath: trimmedDeveloperDirectoryPath, directoryHint: .isDirectory)
+			.deletingLastPathComponent()
+			.appending(path: "Applications", directoryHint: .isDirectory)
+			.appending(path: "DeviceHub.app", directoryHint: .isDirectory)
+
+		guard FileManager.default.fileExists(atPath: deviceHubURL.path(percentEncoded: false)) else {
+			return nil
+		}
+
+		return deviceHubURL
+	}
+}


### PR DESCRIPTION
### What does this change accomplish?

This change adds support for Xcode 27's new Device Hub app, the replacement for `Simulator.app`. Currently, Tophat attempts to open whatever `Simulator.app` is available on the system.  On Xcode 27-only installs, this fails outright because the app no longer exists.

### How have you achieved it?

By checking for the presence of the `Device Hub.app` app in the selected Xcode installation and launching it with an app link if it is present, falling back to `Simulator.app` (current behaviour) otherwise.

### How can the change be tested?

1. With Xcode 27 installed and selected, install an app and ensure that it opens Device Hub and switches to the device you selected.
2. Select Xcode 26 and ensure Simulator is launched as before.