### PR TITLE
Bump version to `2.6.0`

### DIFF
--- a/Configurations/Version.xcconfig
+++ b/Configurations/Version.xcconfig
@@ -6,5 +6,5 @@
 //  Copyright © 2024 Shopify. All rights reserved.
 //
 
-MARKETING_VERSION = 2.5.2
+MARKETING_VERSION = 2.6.0
 CURRENT_PROJECT_VERSION = 1


### PR DESCRIPTION
### What does this change accomplish?

This change bumps the version of Tophat to `2.6.0`.

### How have you achieved it?

By modifying `Version.xcconfig`.

### How can the change be tested?

N/A