### PR TITLE
Add support for Xcode Cloud artifacts

### DIFF
--- a/Configurations/TophatXcodeCloudExtension.xcconfig
+++ b/Configurations/TophatXcodeCloudExtension.xcconfig
@@ -1,0 +1,9 @@
+//
+//  TophatXcodeCloudExtension.xcconfig
+//  Tophat
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+#include "Version.xcconfig"

--- a/Tophat.xcodeproj/project.pbxproj
+++ b/Tophat.xcodeproj/project.pbxproj
@@ -11,6 +11,9 @@
 		4D7657472EFA9A8E00319B8C /* TophatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4D7657462EFA9A8E00319B8C /* TophatKit */; };
 		4D94A0C42F34B56200916167 /* SimpleKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 4D94A0C32F34B56200916167 /* SimpleKeychain */; };
 		4D94A0C62F34B56B00916167 /* SimpleKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 4D94A0C52F34B56B00916167 /* SimpleKeychain */; };
+		4DC1D0012F80000100C1D0AA /* TophatXcodeCloudExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = 4DC1D0032F80000100C1D0AA /* TophatXcodeCloudExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4DC1D0022F80000100C1D0AA /* TophatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4DC1D00E2F80000100C1D0AA /* TophatKit */; };
+		4DC1D0102F80000100C1D0AA /* SimpleKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 4DC1D00F2F80000100C1D0AA /* SimpleKeychain */; };
 		7F4532AD251A6C4700F2CFC8 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 7FA71E0924C95CAC001C9574 /* Logging */; };
 		7F4532AF251A6C4700F2CFC8 /* LoggingOSLog in Frameworks */ = {isa = PBXBuildFile; productRef = 7F8EC94425086F3B00D4D42B /* LoggingOSLog */; };
 		8005282F2CB718C200226174 /* TophatKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8005282E2CB718C200226174 /* TophatKit */; };
@@ -41,6 +44,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 4D7657382EFA9A5B00319B8C;
 			remoteInfo = TophatGitHubExtension;
+		};
+		4DC1D0092F80000100C1D0AA /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7F35024724A5060500EE76EA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4DC1D0082F80000100C1D0AA;
+			remoteInfo = TophatXcodeCloudExtension;
 		};
 		7F35026524A5060600EE76EA /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -102,6 +112,7 @@
 				808C6E3A2CF8D81F0030359E /* TophatBitriseExtension.appex in CopyFiles */,
 				80D648552CB0E20C00135729 /* TophatCoreExtension.appex in CopyFiles */,
 				4D7657402EFA9A5B00319B8C /* TophatGitHubActionsExtension.appex in CopyFiles */,
+				4DC1D0012F80000100C1D0AA /* TophatXcodeCloudExtension.appex in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,6 +130,7 @@
 
 /* Begin PBXFileReference section */
 		4D7657392EFA9A5B00319B8C /* TophatGitHubActionsExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = TophatGitHubActionsExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		4DC1D0032F80000100C1D0AA /* TophatXcodeCloudExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.extensionkit-extension"; includeInIndex = 0; path = TophatXcodeCloudExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F35024F24A5060500EE76EA /* Tophat.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Tophat.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		7F35026424A5060600EE76EA /* TophatTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TophatTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		8005282D2CB7185E00226174 /* TophatKit */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = TophatKit; sourceTree = "<group>"; };
@@ -142,6 +154,24 @@
 				TophatGitHubActionsExtension/Utilities/SecureStorage.swift,
 			);
 			target = 4D7657382EFA9A5B00319B8C /* TophatGitHubActionsExtension */;
+		};
+		4DC1D0042F80000100C1D0AA /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				TophatXcodeCloudExtension/API/CiArtifactListResponseModel.swift,
+				TophatXcodeCloudExtension/API/CiArtifactResponseItemModel.swift,
+				TophatXcodeCloudExtension/API/CiBuildActionListResponseModel.swift,
+				TophatXcodeCloudExtension/API/CiBuildActionResponseItemModel.swift,
+				TophatXcodeCloudExtension/ArtifactProviders/XcodeCloudArtifactProvider.swift,
+				TophatXcodeCloudExtension/ArtifactProviders/XcodeCloudArtifactProviderError.swift,
+				TophatXcodeCloudExtension/Localizable.xcstrings,
+				TophatXcodeCloudExtension/Settings/Constants.swift,
+				TophatXcodeCloudExtension/Settings/SettingsView.swift,
+				TophatXcodeCloudExtension/TophatXcodeCloudExtension.swift,
+				TophatXcodeCloudExtension/Utilities/AppStoreConnectJWT.swift,
+				TophatXcodeCloudExtension/Utilities/SecureStorage.swift,
+			);
+			target = 4DC1D0082F80000100C1D0AA /* TophatXcodeCloudExtension */;
 		};
 		8001A5962CFE293D00325E7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
@@ -205,7 +235,7 @@
 		8001A59C2CFE294100325E7B /* TophatTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (8001A5A02CFE294100325E7B /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TophatTests; sourceTree = "<group>"; };
 		8001A5AD2CFE294400325E7B /* TophatCtl */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = TophatCtl; sourceTree = "<group>"; };
 		804B75432D07635700986C9E /* Configurations */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = Configurations; sourceTree = "<group>"; };
-		80D648482CB0E1C200135729 /* TophatExtensions */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (80D6485F2CB0E22200135729 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 808C6E442CF8D8260030359E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4D76574C2EFA9AAD00319B8C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TophatExtensions; sourceTree = "<group>"; };
+		80D648482CB0E1C200135729 /* TophatExtensions */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (80D6485F2CB0E22200135729 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 808C6E442CF8D8260030359E /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4D76574C2EFA9AAD00319B8C /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 4DC1D0042F80000100C1D0AA /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TophatExtensions; sourceTree = "<group>"; };
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -215,6 +245,15 @@
 			files = (
 				4D94A0C62F34B56B00916167 /* SimpleKeychain in Frameworks */,
 				4D7657472EFA9A8E00319B8C /* TophatKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DC1D0052F80000100C1D0AA /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4DC1D0102F80000100C1D0AA /* SimpleKeychain in Frameworks */,
+				4DC1D0022F80000100C1D0AA /* TophatKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -306,6 +345,7 @@
 				80D6484D2CB0E20C00135729 /* TophatCoreExtension.appex */,
 				808C6E322CF8D81F0030359E /* TophatBitriseExtension.appex */,
 				4D7657392EFA9A5B00319B8C /* TophatGitHubActionsExtension.appex */,
+				4DC1D0032F80000100C1D0AA /* TophatXcodeCloudExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -334,6 +374,27 @@
 			productReference = 4D7657392EFA9A5B00319B8C /* TophatGitHubActionsExtension.appex */;
 			productType = "com.apple.product-type.extensionkit-extension";
 		};
+		4DC1D0082F80000100C1D0AA /* TophatXcodeCloudExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4DC1D00D2F80000100C1D0AA /* Build configuration list for PBXNativeTarget "TophatXcodeCloudExtension" */;
+			buildPhases = (
+				4DC1D0072F80000100C1D0AA /* Sources */,
+				4DC1D0052F80000100C1D0AA /* Frameworks */,
+				4DC1D0062F80000100C1D0AA /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = TophatXcodeCloudExtension;
+			packageProductDependencies = (
+				4DC1D00E2F80000100C1D0AA /* TophatKit */,
+				4DC1D00F2F80000100C1D0AA /* SimpleKeychain */,
+			);
+			productName = TophatXcodeCloudExtension;
+			productReference = 4DC1D0032F80000100C1D0AA /* TophatXcodeCloudExtension.appex */;
+			productType = "com.apple.product-type.extensionkit-extension";
+		};
 		7F35024E24A5060500EE76EA /* Tophat */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 7F35027824A5060700EE76EA /* Build configuration list for PBXNativeTarget "Tophat" */;
@@ -353,6 +414,7 @@
 				80D648542CB0E20C00135729 /* PBXTargetDependency */,
 				808C6E392CF8D81F0030359E /* PBXTargetDependency */,
 				4D76573F2EFA9A5B00319B8C /* PBXTargetDependency */,
+				4DC1D00A2F80000100C1D0AA /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				8001A5132CFE293D00325E7B /* Tophat */,
@@ -478,6 +540,9 @@
 					4D7657382EFA9A5B00319B8C = {
 						CreatedOnToolsVersion = 26.0;
 					};
+					4DC1D0082F80000100C1D0AA = {
+						CreatedOnToolsVersion = 26.0;
+					};
 					7F35024E24A5060500EE76EA = {
 						CreatedOnToolsVersion = 11.5;
 					};
@@ -526,12 +591,20 @@
 				80D6484C2CB0E20C00135729 /* TophatCoreExtension */,
 				808C6E312CF8D81F0030359E /* TophatBitriseExtension */,
 				4D7657382EFA9A5B00319B8C /* TophatGitHubActionsExtension */,
+				4DC1D0082F80000100C1D0AA /* TophatXcodeCloudExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		4D7657372EFA9A5B00319B8C /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4DC1D0062F80000100C1D0AA /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -598,6 +671,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4DC1D0072F80000100C1D0AA /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		7F35024B24A5060500EE76EA /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -640,6 +720,11 @@
 			isa = PBXTargetDependency;
 			target = 4D7657382EFA9A5B00319B8C /* TophatGitHubActionsExtension */;
 			targetProxy = 4D76573E2EFA9A5B00319B8C /* PBXContainerItemProxy */;
+		};
+		4DC1D00A2F80000100C1D0AA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4DC1D0082F80000100C1D0AA /* TophatXcodeCloudExtension */;
+			targetProxy = 4DC1D0092F80000100C1D0AA /* PBXContainerItemProxy */;
 		};
 		7F35026624A5060600EE76EA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -720,6 +805,69 @@
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Tophat.TophatGitHubActionsExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Release;
+		};
+		4DC1D00B2F80000100C1D0AA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 804B75432D07635700986C9E /* Configurations */;
+			baseConfigurationReferenceRelativePath = TophatXcodeCloudExtension.xcconfig;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = TophatExtensions/TophatXcodeCloudExtension/TophatXcodeCloudExtension.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = A7XGC83MZE;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TophatExtensions/TophatXcodeCloudExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Xcode Cloud";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Shopify. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Tophat.TophatXcodeCloudExtension;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+			};
+			name = Debug;
+		};
+		4DC1D00C2F80000100C1D0AA /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 804B75432D07635700986C9E /* Configurations */;
+			baseConfigurationReferenceRelativePath = TophatXcodeCloudExtension.xcconfig;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_ENTITLEMENTS = TophatExtensions/TophatXcodeCloudExtension/TophatXcodeCloudExtension.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Developer ID Application";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = A7XGC83MZE;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TophatExtensions/TophatXcodeCloudExtension/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Xcode Cloud";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Shopify. All rights reserved.";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+					"@executable_path/../../../../Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.shopify.Tophat.TophatXcodeCloudExtension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
@@ -1131,6 +1279,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		4DC1D00D2F80000100C1D0AA /* Build configuration list for PBXNativeTarget "TophatXcodeCloudExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4DC1D00B2F80000100C1D0AA /* Debug */,
+				4DC1D00C2F80000100C1D0AA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		7F35024A24A5060500EE76EA /* Build configuration list for PBXProject "Tophat" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1273,6 +1430,15 @@
 			productName = SimpleKeychain;
 		};
 		4D94A0C52F34B56B00916167 /* SimpleKeychain */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4D94A0BF2F34B4FB00916167 /* XCRemoteSwiftPackageReference "SimpleKeychain" */;
+			productName = SimpleKeychain;
+		};
+		4DC1D00E2F80000100C1D0AA /* TophatKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = TophatKit;
+		};
+		4DC1D00F2F80000100C1D0AA /* SimpleKeychain */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4D94A0BF2F34B4FB00916167 /* XCRemoteSwiftPackageReference "SimpleKeychain" */;
 			productName = SimpleKeychain;

--- a/Tophat/Utilities/ArtifactUnpacker.swift
+++ b/Tophat/Utilities/ArtifactUnpacker.swift
@@ -28,21 +28,11 @@ final class ArtifactUnpacker: Sendable {
 				throw ArtifactUnpackerError.unknownFileFormat
 			}
 
-			let enclosedFileURLs = try FileManager.default.contentsOfDirectory(
-				at: artifactURL,
-				includingPropertiesForKeys: nil
-			)
-
-			let supportedPathExtensions = ArtifactFileFormat.allCases.map(\.pathExtension)
-			let firstSupportedEnclosedFileURL = enclosedFileURLs.first { fileURL in
-				supportedPathExtensions.contains(fileURL.pathExtension)
-			}
-
-			guard let firstSupportedEnclosedFileURL else {
+			guard let enclosedArtifactURL = try findSupportedArtifact(in: artifactURL) else {
 				throw ArtifactUnpackerError.unknownFileFormat
 			}
 
-			return try unpack(artifactURL: firstSupportedEnclosedFileURL)
+			return try unpack(artifactURL: enclosedArtifactURL)
 		}
 
 		switch fileFormat {
@@ -75,6 +65,35 @@ final class ArtifactUnpacker: Sendable {
 		}
 
 		return fileURL
+	}
+
+	/// Recursively searches a directory tree for the first file or directory matching a supported
+	/// artifact format, such as when an application bundle is nested within intermediate build
+	/// output directories (e.g. an Xcode Cloud build products archive).
+	///
+	/// Directories that themselves match a supported format are treated as leaves and are not
+	/// searched any further.
+	private func findSupportedArtifact(in directoryURL: URL) throws -> URL? {
+		let supportedPathExtensions = ArtifactFileFormat.allCases.map(\.pathExtension)
+
+		let enclosedFileURLs = try FileManager.default.contentsOfDirectory(
+			at: directoryURL,
+			includingPropertiesForKeys: [.isDirectoryKey]
+		)
+
+		if let match = enclosedFileURLs.first(where: { supportedPathExtensions.contains($0.pathExtension) }) {
+			return match
+		}
+
+		// Descend in a stable order so that an archive containing more than one nested
+		// artifact resolves to the same one every time.
+		for fileURL in enclosedFileURLs.sorted(using: KeyPathComparator(\.path)) where fileURL.isDirectory {
+			if let match = try findSupportedArtifact(in: fileURL) {
+				return match
+			}
+		}
+
+		return nil
 	}
 
 	private func extractArtifact(at url: URL) throws -> URL {

--- a/TophatExtensions/TophatXcodeCloudExtension/API/CiArtifactListResponseModel.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/API/CiArtifactListResponseModel.swift
@@ -1,0 +1,13 @@
+//
+//  CiArtifactListResponseModel.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+
+struct CiArtifactListResponseModel: Decodable {
+	var data: [CiArtifactResponseItemModel]
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/API/CiArtifactResponseItemModel.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/API/CiArtifactResponseItemModel.swift
@@ -1,0 +1,38 @@
+//
+//  CiArtifactResponseItemModel.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+
+struct CiArtifactResponseItemModel: Decodable {
+	var id: String
+	var attributes: Attributes?
+
+	struct Attributes: Decodable {
+		var fileName: String?
+		var fileSize: Int?
+		var fileType: String?
+		var downloadURL: URL?
+
+		enum CodingKeys: String, CodingKey {
+			case fileName
+			case fileSize
+			case fileType
+			case downloadURL = "downloadUrl"
+		}
+	}
+}
+
+extension CiArtifactResponseItemModel {
+	/// The products that `xcodebuild` wrote to its build directory, which contain the
+	/// application bundle that can be installed onto a simulator.
+	static let buildProductsFileType = "XCODEBUILD_PRODUCTS"
+
+	/// An export of an archive, which contains the App Store package to install onto a
+	/// device. A build action produces one export for each configured export method.
+	static let archiveExportFileType = "ARCHIVE_EXPORT"
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/API/CiBuildActionListResponseModel.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/API/CiBuildActionListResponseModel.swift
@@ -1,0 +1,13 @@
+//
+//  CiBuildActionListResponseModel.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+
+struct CiBuildActionListResponseModel: Decodable {
+	var data: [CiBuildActionResponseItemModel]
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/API/CiBuildActionResponseItemModel.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/API/CiBuildActionResponseItemModel.swift
@@ -1,0 +1,13 @@
+//
+//  CiBuildActionResponseItemModel.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+
+struct CiBuildActionResponseItemModel: Decodable {
+	var id: String
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/ArtifactProviders/XcodeCloudArtifactProvider.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/ArtifactProviders/XcodeCloudArtifactProvider.swift
@@ -1,0 +1,195 @@
+//
+//  XcodeCloudArtifactProvider.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+import TophatKit
+
+struct XcodeCloudArtifactProvider: ArtifactProvider {
+	@SecureStorage(Constants.keychainIssuerIDKey) var issuerID: String?
+	@SecureStorage(Constants.keychainKeyIDKey) var keyID: String?
+	@SecureStorage(Constants.keychainPrivateKeyKey) var privateKey: String?
+
+	static let id = "xcode-cloud"
+	static let title: LocalizedStringResource = "Xcode Cloud"
+
+	private let baseURL = URL(string: "https://api.appstoreconnect.apple.com/v1")!
+
+	@Parameter(
+		key: "build_run_id",
+		title: "Build Run ID",
+		description: "The identifier of the Xcode Cloud build, available as CI_BUILD_ID in a custom build script.",
+		prompt: "Build Run ID"
+	)
+	var buildRunID: String
+
+	@Parameter(
+		key: "artifact",
+		title: "Artifact",
+		description: "Use “build-products” to install on a simulator, or the name of an export such as “development” or “ad-hoc” to install on a device.",
+		prompt: "Artifact Name"
+	)
+	var artifact: String
+
+	private var buildActionsURL: URL {
+		baseURL
+			.appending(path: "ciBuildRuns")
+			.appending(path: buildRunID)
+			.appending(path: "actions")
+	}
+
+	func retrieve() async throws -> some ArtifactProviderResult {
+		guard
+			let issuerID, !issuerID.isEmpty,
+			let keyID, !keyID.isEmpty,
+			let privateKey, !privateKey.isEmpty
+		else {
+			throw XcodeCloudArtifactProviderError.credentialsNotSet
+		}
+
+		let token = try AppStoreConnectJWT(issuerID: issuerID, keyID: keyID, privateKey: privateKey).makeToken()
+
+		// Fetch actions for build.
+
+		let buildActionsRequest = makeAuthenticatedURLRequest(url: buildActionsURL, token: token)
+		let (buildActionsResponseData, buildActionsResponse) = try await URLSession.shared.data(for: buildActionsRequest)
+		try validateResponse(buildActionsResponse)
+		let buildActionsListResponse = try JSONDecoder().decode(CiBuildActionListResponseModel.self, from: buildActionsResponseData)
+
+		// Fetch artifacts for each action until a match is found. A workflow can define
+		// more than one action, and each produces its own artifacts, so the one being
+		// asked for may belong to any of them.
+
+		var matchingArtifact: CiArtifactResponseItemModel?
+
+		for buildAction in buildActionsListResponse.data {
+			let artifactsURL = baseURL
+				.appending(path: "ciBuildActions")
+				.appending(path: buildAction.id)
+				.appending(path: "artifacts")
+
+			let artifactsRequest = makeAuthenticatedURLRequest(url: artifactsURL, token: token)
+			let (artifactsResponseData, artifactsResponse) = try await URLSession.shared.data(for: artifactsRequest)
+			try validateResponse(artifactsResponse)
+			let artifactsListResponse = try JSONDecoder().decode(CiArtifactListResponseModel.self, from: artifactsResponseData)
+
+			if let match = artifactsListResponse.data.first(where: matches(artifact:)) {
+				matchingArtifact = match
+				break
+			}
+		}
+
+		guard let matchingArtifact else {
+			throw XcodeCloudArtifactProviderError.artifactNotFound
+		}
+
+		guard let downloadURL = matchingArtifact.attributes?.downloadURL else {
+			throw XcodeCloudArtifactProviderError.artifactNotReady
+		}
+
+		// Download artifact. The URL is pre-signed, so no authorization header is needed.
+
+		let (downloadedFileURL, downloadResponse) = try await URLSession.shared.download(from: downloadURL)
+		try validateDownloadResponse(downloadResponse)
+
+		let destinationDirectoryURL: URL = .temporaryDirectory.appending(path: UUID().uuidString)
+		try FileManager.default.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
+
+		// Tophat determines how to unpack an artifact from its path extension, so the name
+		// reported by App Store Connect is preferred over the one suggested by the download.
+		let fileName = matchingArtifact.attributes?.fileName
+			?? downloadResponse.suggestedFilename
+			?? downloadedFileURL.lastPathComponent
+
+		let destinationURL = destinationDirectoryURL.appending(component: fileName)
+		try FileManager.default.moveItem(at: downloadedFileURL, to: destinationURL)
+
+		return .result(localURL: destinationURL)
+	}
+
+	func cleanUp(localURL: URL) async throws {
+		try FileManager.default.removeItem(at: localURL)
+	}
+}
+
+private extension XcodeCloudArtifactProvider {
+	/// The value of the artifact parameter that selects the products of a build action rather
+	/// than an export of an archive.
+	static let buildProductsArtifact = "build-products"
+
+	func makeAuthenticatedURLRequest(url: URL, token: String) -> URLRequest {
+		var request = URLRequest(url: url)
+		request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+		request.setValue("application/json", forHTTPHeaderField: "Accept")
+		return request
+	}
+
+	/// Determines whether an artifact is the one that the artifact parameter selects.
+	///
+	/// Xcode Cloud names an export after the method that produced it, such as
+	/// `MyApp 1.0.2 development.zip`, so the trailing component of the name identifies the
+	/// export and stays stable across builds.
+	func matches(artifact candidate: CiArtifactResponseItemModel) -> Bool {
+		guard let attributes = candidate.attributes else {
+			return false
+		}
+
+		if artifact == Self.buildProductsArtifact {
+			return attributes.fileType == CiArtifactResponseItemModel.buildProductsFileType
+		}
+
+		guard
+			attributes.fileType == CiArtifactResponseItemModel.archiveExportFileType,
+			let fileName = attributes.fileName,
+			let exportMethod = URL(fileURLWithPath: fileName)
+				.deletingPathExtension()
+				.lastPathComponent
+				.split(separator: " ")
+				.last
+		else {
+			return false
+		}
+
+		return String(exportMethod) == artifact
+	}
+
+	func validateResponse(_ response: URLResponse) throws {
+		guard let httpResponse = response as? HTTPURLResponse else {
+			throw XcodeCloudArtifactProviderError.unexpected
+		}
+
+		guard httpResponse.statusCode == 200 else {
+			switch httpResponse.statusCode {
+				case 401:
+					throw XcodeCloudArtifactProviderError.unauthorized
+				case 403:
+					throw XcodeCloudArtifactProviderError.forbidden
+				case 404:
+					throw XcodeCloudArtifactProviderError.buildRunNotFound
+				default:
+					throw XcodeCloudArtifactProviderError.unexpected
+			}
+		}
+	}
+
+	/// Validates a response from the pre-signed download URL. A rejection here means the
+	/// artifact can no longer be retrieved rather than that the build could not be found.
+	func validateDownloadResponse(_ response: URLResponse) throws {
+		guard let httpResponse = response as? HTTPURLResponse else {
+			throw XcodeCloudArtifactProviderError.unexpected
+		}
+
+		guard httpResponse.statusCode == 200 else {
+			switch httpResponse.statusCode {
+				case 403, 404, 410:
+					throw XcodeCloudArtifactProviderError.artifactExpired
+				default:
+					throw XcodeCloudArtifactProviderError.unexpected
+			}
+		}
+	}
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/ArtifactProviders/XcodeCloudArtifactProviderError.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/ArtifactProviders/XcodeCloudArtifactProviderError.swift
@@ -1,0 +1,73 @@
+//
+//  XcodeCloudArtifactProviderError.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+
+enum XcodeCloudArtifactProviderError: Error {
+	case credentialsNotSet
+	case invalidPrivateKey
+	case unauthorized
+	case forbidden
+	case buildRunNotFound
+	case artifactNotFound
+	case artifactNotReady
+	case artifactExpired
+	case unexpected
+}
+
+extension XcodeCloudArtifactProviderError: LocalizedError {
+	var errorDescription: String? {
+		"Failed to Download Artifact"
+	}
+
+	var failureReason: String? {
+		switch self {
+			case .credentialsNotSet:
+				"An App Store Connect API key is required."
+			case .invalidPrivateKey:
+				"The private key used to authenticate with App Store Connect could not be read."
+			case .unauthorized:
+				"The API key used to authenticate with App Store Connect is invalid."
+			case .forbidden:
+				"The API key does not have permission to read Xcode Cloud builds."
+			case .buildRunNotFound:
+				"The requested Xcode Cloud build was not found."
+			case .artifactNotFound:
+				"The Xcode Cloud build did not produce the requested artifact."
+			case .artifactNotReady:
+				"The build products for this Xcode Cloud build are not available yet."
+			case .artifactExpired:
+				"The build products for this Xcode Cloud build are no longer available. They may have expired."
+			case .unexpected:
+				"Something went wrong that Tophat wasn’t able to identify."
+		}
+	}
+
+	var recoverySuggestion: String? {
+		switch self {
+			case .credentialsNotSet:
+				"Go to Tophat Settings → Extensions → Xcode Cloud to add an API key."
+			case .invalidPrivateKey:
+				"Go to Tophat Settings → Extensions → Xcode Cloud and paste the contents of the .p8 file again."
+			case .unauthorized:
+				"Go to Tophat Settings → Extensions → Xcode Cloud to update the API key."
+			case .forbidden:
+				"Create a team API key with a role that can read Xcode Cloud builds and add it in Tophat Settings → Extensions → Xcode Cloud."
+			case .buildRunNotFound:
+				"Check that the build still exists and has not been deleted."
+			case .artifactNotFound:
+				"Check the artifact name against the artifacts listed for the build in App Store Connect."
+			case .artifactNotReady:
+				"Wait for the build to finish and try again."
+			case .artifactExpired:
+				"Start a new build in Xcode Cloud to produce fresh build products."
+			case .unexpected:
+				"Try again later."
+		}
+	}
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/Info.plist
+++ b/TophatExtensions/TophatXcodeCloudExtension/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>EXAppExtensionAttributes</key>
+	<dict>
+		<key>EXExtensionPointIdentifier</key>
+		<string>com.shopify.Tophat.extension</string>
+	</dict>
+</dict>
+</plist>

--- a/TophatExtensions/TophatXcodeCloudExtension/Localizable.xcstrings
+++ b/TophatExtensions/TophatXcodeCloudExtension/Localizable.xcstrings
@@ -1,0 +1,42 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "Artifact" : {
+
+    },
+    "Artifact Name" : {
+
+    },
+    "Authentication" : {
+
+    },
+    "Build Run ID" : {
+
+    },
+    "Contents of the .p8 file" : {
+
+    },
+    "Issuer ID" : {
+
+    },
+    "Key ID" : {
+
+    },
+    "Private Key" : {
+
+    },
+    "The identifier of the Xcode Cloud build, available as CI_BUILD_ID in a custom build script." : {
+
+    },
+    "To create a team API key, go to [appstoreconnect.apple.com/access/integrations/api](https://appstoreconnect.apple.com/access/integrations/api)." : {
+
+    },
+    "Use “build-products” to install on a simulator, or the name of an export such as “development” or “ad-hoc” to install on a device." : {
+
+    },
+    "Xcode Cloud" : {
+
+    }
+  },
+  "version" : "1.1"
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/Settings/Constants.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/Settings/Constants.swift
@@ -1,0 +1,13 @@
+//
+//  Constants.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+enum Constants {
+	static let keychainIssuerIDKey = "TophatXcodeCloudIssuerID"
+	static let keychainKeyIDKey = "TophatXcodeCloudKeyID"
+	static let keychainPrivateKeyKey = "TophatXcodeCloudPrivateKey"
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/Settings/SettingsView.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/Settings/SettingsView.swift
@@ -1,0 +1,49 @@
+//
+//  SettingsView.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import SwiftUI
+import TophatKit
+
+struct SettingsView: View {
+	@SecureStorage(Constants.keychainIssuerIDKey) var storedIssuerID: String?
+	@SecureStorage(Constants.keychainKeyIDKey) var storedKeyID: String?
+	@SecureStorage(Constants.keychainPrivateKeyKey) var storedPrivateKey: String?
+
+	@State private var enteredIssuerID = ""
+	@State private var enteredKeyID = ""
+	@State private var enteredPrivateKey = ""
+
+	var body: some View {
+		Form {
+			Section("Authentication") {
+				TextField("Issuer ID", text: $enteredIssuerID, prompt: Text("Issuer ID"))
+				TextField("Key ID", text: $enteredKeyID, prompt: Text("Key ID"))
+				SecureField("Private Key", text: $enteredPrivateKey, prompt: Text("Contents of the .p8 file"))
+
+				Text("To create a team API key, go to [appstoreconnect.apple.com/access/integrations/api](https://appstoreconnect.apple.com/access/integrations/api).")
+					.font(.subheadline)
+					.foregroundColor(.secondary)
+			}
+		}
+		.formStyle(.grouped)
+		.onAppear {
+			enteredIssuerID = storedIssuerID ?? ""
+			enteredKeyID = storedKeyID ?? ""
+			enteredPrivateKey = storedPrivateKey ?? ""
+		}
+		.onChange(of: enteredIssuerID) { _, newValue in
+			storedIssuerID = newValue.isEmpty ? nil : newValue
+		}
+		.onChange(of: enteredKeyID) { _, newValue in
+			storedKeyID = newValue.isEmpty ? nil : newValue
+		}
+		.onChange(of: enteredPrivateKey) { _, newValue in
+			storedPrivateKey = newValue.isEmpty ? nil : newValue
+		}
+	}
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/TophatXcodeCloudExtension.entitlements
+++ b/TophatExtensions/TophatXcodeCloudExtension/TophatXcodeCloudExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/TophatExtensions/TophatXcodeCloudExtension/TophatXcodeCloudExtension.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/TophatXcodeCloudExtension.swift
@@ -1,0 +1,23 @@
+//
+//  TophatXcodeCloudExtension.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import SwiftUI
+import TophatKit
+
+@main
+struct TophatXcodeCloudExtension: TophatExtension, ArtifactProviding, SettingsProviding {
+	static let title: LocalizedStringResource = "Xcode Cloud"
+
+	static var artifactProviders: some ArtifactProviders {
+		XcodeCloudArtifactProvider()
+	}
+
+	static var settings: some View {
+		SettingsView()
+	}
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/Utilities/AppStoreConnectJWT.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/Utilities/AppStoreConnectJWT.swift
@@ -1,0 +1,112 @@
+//
+//  AppStoreConnectJWT.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import Foundation
+import CryptoKit
+
+/// Creates the signed JSON Web Tokens that authorize App Store Connect API requests.
+///
+/// App Store Connect requires every request to carry a token signed with the ES256
+/// algorithm using the private key downloaded from App Store Connect.
+struct AppStoreConnectJWT {
+	let issuerID: String
+	let keyID: String
+	let privateKey: String
+
+	/// App Store Connect rejects tokens that expire more than 20 minutes in the future.
+	private static let lifetime: TimeInterval = 10 * 60
+
+	private static let audience = "appstoreconnect-v1"
+	private static let algorithm = "ES256"
+	private static let type = "JWT"
+
+	func makeToken(issuedAt: Date = Date()) throws -> String {
+		let signingKey = try makeSigningKey()
+
+		let header = Header(alg: Self.algorithm, kid: keyID, typ: Self.type)
+
+		let payload = Payload(
+			iss: issuerID,
+			iat: Int(issuedAt.timeIntervalSince1970),
+			exp: Int(issuedAt.addingTimeInterval(Self.lifetime).timeIntervalSince1970),
+			aud: Self.audience
+		)
+
+		let encoder = JSONEncoder()
+
+		let signingInput = [
+			try encoder.encode(header).base64URLEncodedString(),
+			try encoder.encode(payload).base64URLEncodedString()
+		].joined(separator: ".")
+
+		// JWT requires the raw r || s form of the signature rather than the DER encoding.
+		let signature = try signingKey.signature(for: Data(signingInput.utf8))
+
+		return "\(signingInput).\(signature.rawRepresentation.base64URLEncodedString())"
+	}
+
+	private func makeSigningKey() throws -> P256.Signing.PrivateKey {
+		do {
+			return try P256.Signing.PrivateKey(pemRepresentation: Self.normalizedPEM(from: privateKey))
+		} catch {
+			throw XcodeCloudArtifactProviderError.invalidPrivateKey
+		}
+	}
+}
+
+private extension AppStoreConnectJWT {
+	struct Header: Encodable {
+		let alg: String
+		let kid: String
+		let typ: String
+	}
+
+	struct Payload: Encodable {
+		let iss: String
+		let iat: Int
+		let exp: Int
+		let aud: String
+	}
+
+	/// Rebuilds a PKCS #8 PEM document from the key material.
+	///
+	/// Pasting the contents of a `.p8` file into a text field often collapses or strips the
+	/// line breaks, and people sometimes paste only the Base64 body. Normalizing the input
+	/// makes all of those forms acceptable.
+	static func normalizedPEM(from rawValue: String) -> String {
+		var body = rawValue
+
+		for marker in ["-----BEGIN PRIVATE KEY-----", "-----END PRIVATE KEY-----"] {
+			body = body.replacingOccurrences(of: marker, with: "")
+		}
+
+		body = body.filter { !$0.isWhitespace }
+
+		var lines: [String] = []
+		var lineStart = body.startIndex
+
+		while lineStart < body.endIndex {
+			let lineEnd = body.index(lineStart, offsetBy: 64, limitedBy: body.endIndex) ?? body.endIndex
+			lines.append(String(body[lineStart..<lineEnd]))
+			lineStart = lineEnd
+		}
+
+		return (["-----BEGIN PRIVATE KEY-----"] + lines + ["-----END PRIVATE KEY-----"])
+			.joined(separator: "\n")
+	}
+}
+
+private extension Data {
+	/// Encodes the data using the unpadded, URL-safe Base64 alphabet that JWT requires.
+	func base64URLEncodedString() -> String {
+		base64EncodedString()
+			.replacingOccurrences(of: "+", with: "-")
+			.replacingOccurrences(of: "/", with: "_")
+			.replacingOccurrences(of: "=", with: "")
+	}
+}

--- a/TophatExtensions/TophatXcodeCloudExtension/Utilities/SecureStorage.swift
+++ b/TophatExtensions/TophatXcodeCloudExtension/Utilities/SecureStorage.swift
@@ -1,0 +1,33 @@
+//
+//  SecureStorage.swift
+//  TophatXcodeCloudExtension
+//
+//  Created by Masahiro Kusumoto on 2026-08-25.
+//  Copyright © 2026 Shopify. All rights reserved.
+//
+
+import SwiftUI
+import SimpleKeychain
+
+@propertyWrapper
+struct SecureStorage {
+	private let key: String
+	private let keychain = SimpleKeychain()
+
+	init(_ key: String) {
+		self.key = key
+	}
+
+	var wrappedValue: String? {
+		get {
+			try? keychain.string(forKey: key)
+		}
+		nonmutating set {
+			if let newValue {
+				try? keychain.set(newValue, forKey: key)
+			} else {
+				try? keychain.deleteItem(forKey: key)
+			}
+		}
+	}
+}


### PR DESCRIPTION
### What does this change accomplish?

This adds a new extension that provides first-class support for Xcode Cloud to Tophat.

Resolves #152

The download links that App Store Connect shows depend on an authenticated browser
session, so passing one to the built-in `http` provider returns `401 Unauthorized`.
Teams have to re-upload the artifact that Xcode Cloud already stores just so Tophat
can reach it. The App Store Connect API returns a pre-signed `downloadUrl` for the
same artifact, which needs no authentication.

| Extensions settings | Xcode Cloud settings |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d48c5785-b357-4a02-9e1f-9948d3604cd8" width="380"/> | <img src="https://github.com/user-attachments/assets/813135b8-f4aa-4f16-9e07-4e9686d831d5" width="380"/> |

### How have you achieved it?

Adds an extension target `TophatXcodeCloudExtension` with a provider `xcode-cloud`,
which takes the identifier of a build run — available as
[`CI_BUILD_ID`](https://developer.apple.com/documentation/xcode/environment-variable-reference)
in a custom build script — and walks `ciBuildRuns` → `ciBuildActions` → `ciArtifacts`
to find the requested artifact. Taking an identifier rather than a link means a URL can
be generated before the artifact exists.

- Authentication uses an App Store Connect API key, stored in the keychain. `CryptoKit`
  covers both the PKCS #8 key and the ES256 signature, so this adds no dependency. The
  **Developer** role is enough, since only GET requests are made.
- Artifacts are named rather than inferred, as in the Bitrise extension. An archive
  action produces one export per method (`development`, `ad-hoc`, `app-store`) that all
  share a `fileType`, so only the trailing component of the name is matched — their
  names embed a version that changes between builds.
- `ArtifactUnpacker` now searches the directory tree. Xcode Cloud nests the payload more
  than one level deep, so both layouts previously failed with `unknownFileFormat`. This
  is the only change outside the new extension, kept as its own commit; I confirmed that
  every layout existing providers resolve today still resolves to the same artifact.

### How can the change be tested?

You'll need an app built by Xcode Cloud. In the workflow, the action decides which
artifact you can install:

| To install on | Use | Artifact you ask for |
| --- | --- | --- |
| a simulator | a **Build** action with **Any iOS Simulator** as its destination | `build-products` |
| a device | an **Archive** action | `development` |

A workflow can hold both actions, in which case the same build run carries both
artifacts.

A build action set to **Any iOS Device** is not a substitute for the archive: it does
produce an `arm64` bundle, but one signed ad hoc with no provisioning profile, which a
device refuses. Tophat reports this as *"This device requires the app to be signed with
an Apple Development or Enterprise certificate."*

1. Create an API key at
   [appstoreconnect.apple.com/access/integrations/api](https://appstoreconnect.apple.com/access/integrations/api).
   Under **Team Keys**, generate one with the **Developer** role and keep the Issuer ID,
   the Key ID, and the `AuthKey_XXXXXXXXXX.p8` file (downloadable only once).
2. Go to **Settings → Extensions → Xcode Cloud** and enter those three values.
3. Take a build run identifier from the URL of a build in App Store Connect:
   `…/ci/builds/<build run id>`.
4. Open the link below. The app should install and launch on the selected simulator.

   ```
   tophat://install/xcode-cloud?build_run_id=<build run id>&artifact=build-products&platform=ios&destination=simulator
   ```

<img width="200" alt="03-simulator-app-running" src="https://github.com/user-attachments/assets/eb4af1b1-da4d-405e-b2a1-b9f5d740037c" />

To install on a device, use a build whose workflow has an archive action and name the
export instead: `&artifact=development&destination=device`. The provider also appears in
Quick Launch, where `Build Run ID` and `Artifact` are ordinary fields.

I verified both on a real project, reaching them from links that Xcode Cloud posted to a
pull request. That is the workflow this is meant for: a build script has the build
identifier while the build is still running, so it can post a working link before the
artifact has finished uploading.

The workflow I tested against defines both a build and an archive action, so the script
ran once per action and posted two links against the same build — one for the simulator,
one for a device — and both installed. Worth noting because the artifact you ask for is
not necessarily produced by the action you are running under: `build-products` lives on
the build action even when the archive action is listed first, which is why each action
is searched.

<details>
<summary>The <code>ci_post_xcodebuild.sh</code> I used to post those links</summary>

`GITHUB_TOKEN` is a secret environment variable on the Xcode Cloud workflow, holding a
fine-grained personal access token scoped to the repository with **Pull requests: Read
and write**. Everything else comes from the environment Xcode Cloud already provides —
see [Environment variable reference](https://developer.apple.com/documentation/xcode/environment-variable-reference).

```bash
#!/bin/bash
set -e

[[ -n ${CI_PULL_REQUEST_NUMBER:-} ]] || exit 0

# A build action produces the simulator build; an archive action produces the
# exports. Ask for whichever this action leaves behind.
case ${CI_XCODEBUILD_ACTION:-} in
  archive) ARTIFACT="development";    DESTINATION="device"    ;;
  *)       ARTIFACT="build-products"; DESTINATION="simulator" ;;
esac

# GitHub strips the tophat:// scheme from comments, so use the http form.
TOPHAT_URL="http://localhost:29070/install/xcode-cloud"
TOPHAT_URL="${TOPHAT_URL}?build_run_id=${CI_BUILD_ID}"
TOPHAT_URL="${TOPHAT_URL}&artifact=${ARTIFACT}"
TOPHAT_URL="${TOPHAT_URL}&platform=ios&destination=${DESTINATION}"

BODY=$(cat <<EOF
Xcode Cloud finished the \`${CI_XCODEBUILD_ACTION}\` action.

<a href="${TOPHAT_URL}">Install with Tophat</a>
EOF
)

jq -n --arg body "$BODY" '{body: $body}' > payload.json
curl -sS --fail-with-body -X POST \
  -H "Authorization: token ${GITHUB_TOKEN}" \
  -H "Accept: application/vnd.github+json" \
  "https://api.github.com/repos/${CI_PULL_REQUEST_TARGET_REPO}/issues/${CI_PULL_REQUEST_NUMBER}/comments" \
  -d @payload.json
```

One link per action, rather than one link naming several artifacts: repeating the
parameters creates several recipes that all run against the selected device, so it is
not a way to choose between them.

</details>
